### PR TITLE
Add pre commit hook

### DIFF
--- a/App.test.js
+++ b/App.test.js
@@ -5,5 +5,5 @@ import renderer from 'react-test-renderer';
 
 it('renders without crashing', () => {
   const rendered = renderer.create(<App />).toJSON();
-  expect(rendered).toBeTruthy();
+  expect(rendered).toBeFalsy();
 });

--- a/App.test.js
+++ b/App.test.js
@@ -5,5 +5,5 @@ import renderer from 'react-test-renderer';
 
 it('renders without crashing', () => {
   const rendered = renderer.create(<App />).toJSON();
-  expect(rendered).toBeFalsy();
+  expect(rendered).toBeTruthy();
 });

--- a/README.md
+++ b/README.md
@@ -10,9 +10,36 @@
 |Desktop Web|:white_check_mark:|Would be nice to have but I'd rather focus on mobile versions|
 |Windows Phone|:x:|React Native's Documentation is mostly focused on Android and iOS, Windows Phone has been [discontinued](https://www.cnet.com/news/windows-10-mobile-features-hardware-death-sentence-microsoft/)|
 
-## Git workflow
+## Development
 
-### Commits
+This project was bootstrapped with [Create React Native App](https://github.com/react-community/create-react-native-app).
+
+### Git workflow
+
+In order to add a new feature/bug fix, follow these steps:
+
+- Get the latest updates
+
+```
+git fetch origin
+git checkout master
+git pull origin master
+```
+
+- Create your own branch
+
+```
+git checkout -b your-branch-name
+```
+
+- Work, work, work on it by editing the code locally then pushing it to your branch
+- Once the feature/bug fix looks correct, create a Pull Request to merge your commits into `master` from `your-branch-name`
+
+#### Branches
+
+Branches should have a clear name, be short and only use `a-z` and `-`.
+
+#### Commits
 
 :cop: Commit messages should be semantic thanks to this [rigid format](https://seesparkbox.com/foundry/semantic_commit_messages), i.e. they should start with one of these values:
 `['chore:', 'docs:', 'feat:', 'fix:', 'refactor:', 'style:', 'test:']`

--- a/package-lock.json
+++ b/package-lock.json
@@ -7581,6 +7581,12 @@
         "win-release": "1.1.1"
       }
     },
+    "os-shim": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
+      "dev": true
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -7849,6 +7855,28 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-1.0.1.tgz",
       "integrity": "sha1-/mOhfal3YRq+98uAJssalVP9g1k="
+    },
+    "pre-commit": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
+      "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "spawn-sync": "1.0.15",
+        "which": "1.2.14"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.2.14",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+          "dev": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        }
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -9696,6 +9724,16 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+    },
+    "spawn-sync": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.2",
+        "os-shim": "0.1.3"
+      }
     },
     "spdx-correct": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
-    "react-native-scripts": "1.14.0",
     "jest-expo": "~27.0.0",
+    "pre-commit": "^1.2.2",
+    "react-native-scripts": "1.14.0",
     "react-test-renderer": "16.3.1"
   },
   "main": "./node_modules/react-native-scripts/build/bin/crna-entry.js",
@@ -15,6 +16,9 @@
     "ios": "react-native-scripts ios",
     "test": "jest"
   },
+  "pre-commit": [
+    "test"
+  ],
   "jest": {
     "preset": "jest-expo"
   },


### PR DESCRIPTION
## Overview

**Previously,** the unit tests were only run when executing `npm run test`. Because of this, we could commit changes even though 1+ unit test(s) was/were failing.

**Now,** a `pre-commit` hook ensures that all the unit test(s) are passing before being able to commit.

## Testing

On this branch, update a unit test so it fails (e.g. from `toBeTruthy()` to `toBeFalsy()`) then try to commit the change. You should not be able to do so.

## Additional information

Thanks to [this npm module](https://www.npmjs.com/package/pre-commit)