### PR TITLE
Fix test suite

### DIFF
--- a/App.test.js
+++ b/App.test.js
@@ -3,7 +3,7 @@ import App from "./App";
 
 import renderer from "react-test-renderer";
 
-it.skip("renders without crashing", () => {
+it("renders without crashing", () => {
   const rendered = renderer.create(<App />).toJSON();
   expect(rendered).toBeTruthy();
 });

--- a/SectionListBasics.js
+++ b/SectionListBasics.js
@@ -24,7 +24,6 @@ export default class SectionListBasics extends React.Component {
     const { isSearch, searchText } = this.state;
 
     const getXLetterWordsSections = jsonObject => {
-      console.log(jsonObject);
       const allMixedUpWords = isSearch
         ? jsonObject.filter(wordObject =>
             wordObject.englishWord.toLowerCase().includes(searchText)
@@ -51,7 +50,6 @@ export default class SectionListBasics extends React.Component {
       }
 
       return allSortedWords.map(groupOfWords => {
-        console.log(groupOfWords);
         const letterSection = groupOfWords[0][0].toUpperCase();
         return {
           title: `${letterSection} (${pluralize("word", groupOfWords.length)})`,

--- a/SectionListBasics.test.js
+++ b/SectionListBasics.test.js
@@ -1,9 +1,9 @@
 import React from "react";
-import SectionListBasics from "./App";
+import SectionListBasics from "./SectionListBasics";
 
 import renderer from "react-test-renderer";
 
-it.skip("renders without crashing", () => {
+it("renders without crashing", () => {
   const rendered = renderer.create(<SectionListBasics />).toJSON();
   expect(rendered).toBeTruthy();
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -15367,27 +15367,15 @@
       }
     },
     "react-test-renderer": {
-      "version": "16.11.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.11.0.tgz",
-      "integrity": "sha512-nh9gDl8R4ut+ZNNb2EeKO5VMvTKxwzurbSMuGBoKtjpjbg8JK/u3eVPVNi1h1Ue+eYK9oSzJjb+K3lzLxyA4ag==",
+      "version": "16.8.3",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.3.tgz",
+      "integrity": "sha512-rjJGYebduKNZH0k1bUivVrRLX04JfIQ0FKJLPK10TAb06XWhfi4gTobooF9K/DEFNW98iGac3OSxkfIJUN9Mdg==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "react-is": "^16.8.6",
-        "scheduler": "^0.17.0"
-      },
-      "dependencies": {
-        "scheduler": {
-          "version": "0.17.0",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.17.0.tgz",
-          "integrity": "sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
+        "react-is": "^16.8.3",
+        "scheduler": "^0.13.3"
       }
     },
     "react-timer-mixin": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "expo-cli": "^3.4.1",
     "jest-expo": "^35.0.0",
     "pre-commit": "^1.2.2",
-    "react-test-renderer": "^16.11.0"
+    "react-test-renderer": "16.8.3"
   },
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {


### PR DESCRIPTION
## Overview

**Previously,** the 2 unit tests were skipped with `skip`.
**Now,** they are activated back and test suite is ✅ 

## Testing

Run `npm run test`.

## Additional information

Similar to the previous PR, I had to downgrade `react-test-renderer` to same version as `react`