### PR TITLE
Add a Footer to the app

### DIFF
--- a/App/index.test.tsx
+++ b/App/index.test.tsx
@@ -1,7 +1,9 @@
+// Vendor
 import React from "react";
-import App from "./index";
-
 import renderer from "react-test-renderer";
+
+// Internal
+import App from "./index";
 
 it("renders without crashing", () => {
   const rendered = renderer.create(<App />).toJSON();

--- a/App/index.tsx
+++ b/App/index.tsx
@@ -1,3 +1,4 @@
+// Vendor
 import * as Font from "expo-font";
 import * as React from "react";
 import { AppLoading } from "expo";
@@ -5,6 +6,9 @@ import { Container, Text } from "native-base";
 import { Ionicons } from "@expo/vector-icons";
 import { StyleSheet } from "react-native";
 
+// Internal
+import { Footer } from "../Footer";
+import { Screen } from "../types/enum";
 import { SectionListBasics } from "../SectionListBasics";
 import { IS_TEST } from "../config/settings";
 
@@ -36,6 +40,7 @@ const App: React.FC<AppProps> = _props => {
     <Container style={styles.container}>
       <Text>native-base</Text>
       <SectionListBasics letterCount={3} />
+      <Footer screen={Screen.About} />
     </Container>
   );
 };

--- a/App/index.tsx
+++ b/App/index.tsx
@@ -17,6 +17,7 @@ export interface AppProps {}
 const App: React.FC<AppProps> = _props => {
   // Hooks
   const [isReady, setIsReady] = React.useState(false);
+  const [screen, setScreen] = React.useState(Screen.Explore);
 
   // Life-cycle
   React.useEffect(() => {
@@ -36,11 +37,29 @@ const App: React.FC<AppProps> = _props => {
   // Short-circuit
   if (!isReady && !IS_TEST) return <AppLoading />;
 
+  // Handlers
+  const changeScreenAbout = () => {
+    setScreen(Screen.About);
+  };
+
+  const changeScreenConfig = () => {
+    setScreen(Screen.Config);
+  };
+
+  const changeScreenExplore = () => {
+    setScreen(Screen.Explore);
+  };
+
+  // Markup
   return (
     <Container style={styles.container}>
-      <Text>native-base</Text>
       <SectionListBasics letterCount={3} />
-      <Footer screen={Screen.About} />
+      <Footer
+        changeScreenAbout={changeScreenAbout}
+        changeScreenConfig={changeScreenConfig}
+        changeScreenExplore={changeScreenExplore}
+        screen={screen}
+      />
     </Container>
   );
 };

--- a/App/index.tsx
+++ b/App/index.tsx
@@ -38,28 +38,15 @@ const App: React.FC<AppProps> = _props => {
   if (!isReady && !IS_TEST) return <AppLoading />;
 
   // Handlers
-  const changeScreenAbout = () => {
-    setScreen(Screen.About);
-  };
-
-  const changeScreenConfig = () => {
-    setScreen(Screen.Config);
-  };
-
-  const changeScreenExplore = () => {
-    setScreen(Screen.Explore);
+  const changeScreen = (screen: Screen) => {
+    setScreen(screen);
   };
 
   // Markup
   return (
     <Container style={styles.container}>
       <SectionListBasics letterCount={3} />
-      <Footer
-        changeScreenAbout={changeScreenAbout}
-        changeScreenConfig={changeScreenConfig}
-        changeScreenExplore={changeScreenExplore}
-        screen={screen}
-      />
+      <Footer changeScreen={changeScreen} screen={screen} />
     </Container>
   );
 };

--- a/App/index.tsx
+++ b/App/index.tsx
@@ -45,7 +45,7 @@ const App: React.FC<AppProps> = _props => {
   // Markup
   return (
     <Container style={styles.container}>
-      <SectionListBasics letterCount={3} />
+      <SectionListBasics letterCount={2} />
       <Footer changeScreen={changeScreen} screen={screen} />
     </Container>
   );

--- a/Footer.test.tsx
+++ b/Footer.test.tsx
@@ -1,0 +1,13 @@
+// Vendor
+import React from "react";
+import renderer from "react-test-renderer";
+
+// Internal
+import { Footer } from "./Footer";
+import { Screen } from "./types/enum";
+
+it("renders without crashing", () => {
+  const props = { screen: Screen.About };
+  const rendered = renderer.create(<Footer {...props} />).toJSON();
+  expect(rendered).toBeTruthy();
+});

--- a/Footer.tsx
+++ b/Footer.tsx
@@ -1,7 +1,5 @@
 // Vendor
 import * as React from "react";
-
-// Internal
 import {
   FooterTab,
   Footer as FooterNativeBase,
@@ -10,6 +8,7 @@ import {
   Button
 } from "native-base";
 
+// Internal
 import { Screen } from "./types/enum";
 import { IS_TEST } from "./config/settings";
 

--- a/Footer.tsx
+++ b/Footer.tsx
@@ -11,29 +11,37 @@ import { Screen } from "./types/enum";
 import { IS_TEST } from "./config/settings";
 
 export interface FooterProps {
+  changeScreenAbout: () => void;
+  changeScreenConfig: () => void;
+  changeScreenExplore: () => void;
   screen: Screen;
 }
 
 const Footer: React.FC<FooterProps> = props => {
   // Setup
-  const { screen } = props;
+  const {
+    changeScreenAbout,
+    changeScreenConfig,
+    changeScreenExplore,
+    screen
+  } = props;
+
   const isAbout = screen === Screen.About;
   const isConfig = screen === Screen.Config;
   const isExplore = screen === Screen.Explore;
 
-  // TODO: add `onPress` on `Button`
   return (
     <FooterNativeBase>
       <FooterTab>
-        <Button vertical active={isConfig}>
+        <Button vertical active={isConfig} onPress={changeScreenConfig}>
           {!IS_TEST && <Icon name="ios-settings" />}
           <Text>Configuration</Text>
         </Button>
-        <Button vertical active={isExplore}>
+        <Button vertical active={isExplore} onPress={changeScreenExplore}>
           {!IS_TEST && <Icon name="md-globe" />}
           <Text>Explore</Text>
         </Button>
-        <Button vertical active={isAbout}>
+        <Button vertical active={isAbout} onPress={changeScreenAbout}>
           {!IS_TEST && <Icon name="ios-information-circle" />}
           <Text>About</Text>
         </Button>

--- a/Footer.tsx
+++ b/Footer.tsx
@@ -11,20 +11,13 @@ import { Screen } from "./types/enum";
 import { IS_TEST } from "./config/settings";
 
 export interface FooterProps {
-  changeScreenAbout: () => void;
-  changeScreenConfig: () => void;
-  changeScreenExplore: () => void;
+  changeScreen: (screen: Screen) => void;
   screen: Screen;
 }
 
 const Footer: React.FC<FooterProps> = props => {
   // Setup
-  const {
-    changeScreenAbout,
-    changeScreenConfig,
-    changeScreenExplore,
-    screen
-  } = props;
+  const { changeScreen, screen } = props;
 
   const isAbout = screen === Screen.About;
   const isConfig = screen === Screen.Config;
@@ -33,15 +26,27 @@ const Footer: React.FC<FooterProps> = props => {
   return (
     <FooterNativeBase>
       <FooterTab>
-        <Button vertical active={isConfig} onPress={changeScreenConfig}>
+        <Button
+          vertical
+          active={isConfig}
+          onPress={() => changeScreen(Screen.Config)}
+        >
           {!IS_TEST && <Icon name="ios-settings" />}
           <Text>Configuration</Text>
         </Button>
-        <Button vertical active={isExplore} onPress={changeScreenExplore}>
+        <Button
+          vertical
+          active={isExplore}
+          onPress={() => changeScreen(Screen.Explore)}
+        >
           {!IS_TEST && <Icon name="md-globe" />}
           <Text>Explore</Text>
         </Button>
-        <Button vertical active={isAbout} onPress={changeScreenAbout}>
+        <Button
+          vertical
+          active={isAbout}
+          onPress={() => changeScreen(Screen.About)}
+        >
           {!IS_TEST && <Icon name="ios-information-circle" />}
           <Text>About</Text>
         </Button>

--- a/Footer.tsx
+++ b/Footer.tsx
@@ -19,38 +19,50 @@ const Footer: React.FC<FooterProps> = props => {
   // Setup
   const { changeScreen, screen } = props;
 
-  const isAbout = screen === Screen.About;
-  const isConfig = screen === Screen.Config;
-  const isExplore = screen === Screen.Explore;
+  const renderButton = (buttonScreen: Screen) => {
+    const isActive = buttonScreen === screen;
+
+    let iconName = "";
+    let text = "";
+
+    switch (buttonScreen) {
+      case Screen.About:
+        iconName = "ios-information-circle";
+        text = "About";
+        break;
+
+      case Screen.Config:
+        iconName = "ios-settings";
+        text = "Configuration";
+        break;
+
+      case Screen.Explore:
+      default:
+        iconName = "md-globe";
+        text = "Explore";
+        break;
+    }
+
+    return (
+      <Button
+        key={buttonScreen}
+        vertical
+        active={isActive}
+        onPress={() => changeScreen(buttonScreen)}
+      >
+        {!IS_TEST && <Icon name={iconName} />}
+        <Text>{text}</Text>
+      </Button>
+    );
+  };
+
+  const buttons = [Screen.Config, Screen.Explore, Screen.About].map(v =>
+    renderButton(v)
+  );
 
   return (
     <FooterNativeBase>
-      <FooterTab>
-        <Button
-          vertical
-          active={isConfig}
-          onPress={() => changeScreen(Screen.Config)}
-        >
-          {!IS_TEST && <Icon name="ios-settings" />}
-          <Text>Configuration</Text>
-        </Button>
-        <Button
-          vertical
-          active={isExplore}
-          onPress={() => changeScreen(Screen.Explore)}
-        >
-          {!IS_TEST && <Icon name="md-globe" />}
-          <Text>Explore</Text>
-        </Button>
-        <Button
-          vertical
-          active={isAbout}
-          onPress={() => changeScreen(Screen.About)}
-        >
-          {!IS_TEST && <Icon name="ios-information-circle" />}
-          <Text>About</Text>
-        </Button>
-      </FooterTab>
+      <FooterTab>{buttons}</FooterTab>
     </FooterNativeBase>
   );
 };

--- a/Footer.tsx
+++ b/Footer.tsx
@@ -8,6 +8,7 @@ import {
 } from "native-base";
 
 import { Screen } from "./types/enum";
+import { IS_TEST } from "./config/settings";
 
 export interface FooterProps {
   screen: Screen;
@@ -25,15 +26,15 @@ const Footer: React.FC<FooterProps> = props => {
     <FooterNativeBase>
       <FooterTab>
         <Button vertical active={isConfig}>
-          <Icon name="ios-settings" />
-          <Text>Config</Text>
+          {!IS_TEST && <Icon name="ios-settings" />}
+          <Text>Configuration</Text>
         </Button>
         <Button vertical active={isExplore}>
-          <Icon name="md-globe" />
+          {!IS_TEST && <Icon name="md-globe" />}
           <Text>Explore</Text>
         </Button>
         <Button vertical active={isAbout}>
-          <Icon name="ios-information-circle" />
+          {!IS_TEST && <Icon name="ios-information-circle" />}
           <Text>About</Text>
         </Button>
       </FooterTab>

--- a/Footer.tsx
+++ b/Footer.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import {
+  FooterTab,
+  Footer as FooterNativeBase,
+  Icon,
+  Text,
+  Button
+} from "native-base";
+
+import { Screen } from "./types/enum";
+
+export interface FooterProps {
+  screen: Screen;
+}
+
+const Footer: React.FC<FooterProps> = props => {
+  // Setup
+  const { screen } = props;
+  const isAbout = screen === Screen.About;
+  const isConfig = screen === Screen.Config;
+  const isExplore = screen === Screen.Explore;
+
+  // TODO: add `onPress` on `Button`
+  return (
+    <FooterNativeBase>
+      <FooterTab>
+        <Button vertical active={isConfig}>
+          <Icon name="ios-settings" />
+          <Text>Config</Text>
+        </Button>
+        <Button vertical active={isExplore}>
+          <Icon name="md-globe" />
+          <Text>Explore</Text>
+        </Button>
+        <Button vertical active={isAbout}>
+          <Icon name="ios-information-circle" />
+          <Text>About</Text>
+        </Button>
+      </FooterTab>
+    </FooterNativeBase>
+  );
+};
+
+export { Footer };

--- a/Footer.tsx
+++ b/Footer.tsx
@@ -1,4 +1,7 @@
+// Vendor
 import * as React from "react";
+
+// Internal
 import {
   FooterTab,
   Footer as FooterNativeBase,

--- a/SectionListBasics.test.tsx
+++ b/SectionListBasics.test.tsx
@@ -1,7 +1,9 @@
+// Vendor
 import React from "react";
-import { SectionListBasics } from "./SectionListBasics";
-
 import renderer from "react-test-renderer";
+
+// Internal
+import { SectionListBasics } from "./SectionListBasics";
 
 it("renders without crashing", () => {
   const rendered = renderer.create(<SectionListBasics />).toJSON();

--- a/SectionListBasics.tsx
+++ b/SectionListBasics.tsx
@@ -1,6 +1,8 @@
+// Vendor
 import * as React from "react";
 import { SectionList, StyleSheet, Text, TextInput, View } from "react-native";
 
+// Internal
 import { pluralize } from "./helpers/strings";
 import { SelectedLettersText } from "./SelectedLettersText";
 

--- a/SelectedLettersText.test.tsx
+++ b/SelectedLettersText.test.tsx
@@ -1,14 +1,12 @@
+// Vendor
 import React from "react";
-import { SelectedLettersText } from "./SelectedLettersText";
-
 import renderer from "react-test-renderer";
 
-it("renders without crashing", () => {
-  const props = {
-    style: {},
-    text: ""
-  };
+// Internal
+import { SelectedLettersText } from "./SelectedLettersText";
 
+it("renders without crashing", () => {
+  const props = { style: {}, text: "" };
   const rendered = renderer.create(<SelectedLettersText {...props} />).toJSON();
   expect(rendered).toBeTruthy();
 });

--- a/SelectedLettersText.tsx
+++ b/SelectedLettersText.tsx
@@ -1,3 +1,4 @@
+// Vendor
 import * as React from "react";
 import { StyleSheet, Text, View } from "react-native";
 

--- a/types/enum.ts
+++ b/types/enum.ts
@@ -1,0 +1,7 @@
+enum Screen {
+  About,
+  Config,
+  Explore
+}
+
+export { Screen };


### PR DESCRIPTION
# Overview

**Previously,** the app had no footer.
**Now,** the app has a footer with 3 options that can be selected.

# Testing

- [x] `npm run test` should be ✅
- [x] App should be available on a real device (iPhone) after running `npm run start`
- [x] Play around with the footer
