### PR TITLE
Add unit tests to helpers

### DIFF
--- a/SectionListBasics.tsx
+++ b/SectionListBasics.tsx
@@ -48,6 +48,7 @@ const SectionListBasics: React.FC<SectionListBasicsProps> = props => {
         currentLetter = firstEnglishLetter.charCodeAt(0);
       }
     });
+
     if (currentGroupOfWords.length > 0) {
       allSortedWords.push(currentGroupOfWords);
     }

--- a/SelectedLettersText.tsx
+++ b/SelectedLettersText.tsx
@@ -14,6 +14,7 @@ const SelectedLettersText: React.FC<SelectedLettersTextProps> = props => {
   if (!letters) {
     return <Text style={style}>{text}</Text>;
   }
+
   const firstIndex = text.toLowerCase().indexOf(letters.toLowerCase());
   if (firstIndex === -1) {
     return <Text style={style}>{text}</Text>;

--- a/helpers/__tests__/env.test.ts
+++ b/helpers/__tests__/env.test.ts
@@ -9,5 +9,10 @@ describe("env helper", () => {
       result = getFromEnv("NODE_ENV");
       expect(result).toBe("test");
     });
+
+    it("returns empty string otherwise", () => {
+      result = getFromEnv("UNKNOWN");
+      expect(result).toBe("");
+    });
   });
 });

--- a/helpers/__tests__/env.test.ts
+++ b/helpers/__tests__/env.test.ts
@@ -1,0 +1,13 @@
+// Internal
+import { getFromEnv } from "../env";
+
+describe("env helper", () => {
+  describe("getFromEnv", () => {
+    let result: string;
+
+    it("returns environment values", () => {
+      result = getFromEnv("NODE_ENV");
+      expect(result).toBe("test");
+    });
+  });
+});

--- a/helpers/__tests__/strings.test.ts
+++ b/helpers/__tests__/strings.test.ts
@@ -1,0 +1,21 @@
+// Internal
+import { pluralize } from "../strings";
+
+describe("strings helper", () => {
+  describe("pluralize", () => {
+    let result: string;
+
+    it("returns same string if occurrence is 1", () => {
+      result = pluralize("apple", 1);
+      expect(result).toBe("1 apple");
+    });
+
+    it("returns string with an -s if occurrence is not 1", () => {
+      result = pluralize("apple", 0);
+      expect(result).toBe("0 apples");
+
+      result = pluralize("apple", 2);
+      expect(result).toBe("2 apples");
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "test": "jest"
+    "test": "jest",
+    "test:watch": "jest --onlyChanged --watch"
   },
   "pre-commit": [
     "test"


### PR DESCRIPTION
# Overview

**Previously,** helpers had no unit tests whatsoever.
**Now,** they have some.

# Testing

- [x] `npm run test` should be ✅
- [x] Only test files were edited

# Additional information

- I used `__tests__` for the folder name as recommended by jest.
- I added a `watch` option for faster development process
