### PR TITLE
Add better pre-commit hooks

### DIFF
--- a/App/index.test.tsx
+++ b/App/index.test.tsx
@@ -7,5 +7,5 @@ import App from "./index";
 
 it("renders without crashing", () => {
   const rendered = renderer.create(<App />).toJSON();
-  expect(rendered).toBeTruthy();
+  expect(rendered).not.toBeNull();
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2203,6 +2203,12 @@
       "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw==",
       "dev": true
     },
+    "@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
@@ -8485,6 +8491,115 @@
         "ms": "^2.0.0"
       }
     },
+    "husky": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-3.0.9.tgz",
+      "integrity": "sha512-Yolhupm7le2/MqC1VYLk/cNmYxsSsqKkTyBhzQHhPK1jFnC89mmmNVuGtLNabjDI6Aj8UNIr0KpRNuBkiC4+sg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "ci-info": "^2.0.0",
+        "cosmiconfig": "^5.2.1",
+        "execa": "^1.0.0",
+        "get-stdin": "^7.0.0",
+        "opencollective-postinstall": "^2.0.2",
+        "pkg-dir": "^4.2.0",
+        "please-upgrade-node": "^3.2.0",
+        "read-pkg": "^5.2.0",
+        "run-node": "^1.0.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "get-stdin": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+          "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          }
+        }
+      }
+    },
     "hyphenate-style-name": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
@@ -10607,6 +10722,12 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
       }
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
     },
     "load-json-file": {
       "version": "2.0.0",
@@ -13392,12 +13513,6 @@
         "mem": "^4.0.0"
       }
     },
-    "os-shim": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
-      "dev": true
-    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -13921,6 +14036,15 @@
       "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
       "requires": {
         "find-up": "^2.1.0"
+      }
+    },
+    "please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "dev": true,
+      "requires": {
+        "semver-compare": "^1.0.0"
       }
     },
     "plist": {
@@ -14491,28 +14615,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-1.0.1.tgz",
       "integrity": "sha1-/mOhfal3YRq+98uAJssalVP9g1k="
-    },
-    "pre-commit": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
-      "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^5.0.1",
-        "spawn-sync": "^1.0.15",
-        "which": "1.2.x"
-      },
-      "dependencies": {
-        "which": {
-          "version": "1.2.14",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
     },
     "prebuild-install": {
       "version": "5.3.2",
@@ -16344,6 +16446,12 @@
         "is-promise": "^2.1.0"
       }
     },
+    "run-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
+      "integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
+      "dev": true
+    },
     "run-queue": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -16469,6 +16577,12 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
     },
     "send": {
       "version": "0.17.1",
@@ -17084,16 +17198,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
-    },
-    "spawn-sync": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "^1.4.7",
-        "os-shim": "^0.1.2"
-      }
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -18219,6 +18323,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "babel-preset-expo": "^7.1.0",
     "csv-parse": "^4.6.5",
     "expo-cli": "^3.4.1",
+    "husky": "^3.0.9",
     "jest": "^24.9.0",
     "jest-expo": "^35.0.0",
-    "pre-commit": "^1.2.2",
     "react-test-renderer": "16.8.3"
   },
   "main": "node_modules/expo/AppEntry.js",
@@ -27,18 +27,21 @@
   "bugs": {
     "url": "https://github.com/sebranly/WordyWorld/issues"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm run pre-commit"
+    }
+  },
   "scripts": {
     "start": "expo start",
     "eject": "expo eject",
     "android": "expo start --android",
     "ios": "expo start --ios",
+    "pre-commit": "./scripts/pre-commit.sh",
     "web": "expo start --web",
     "test": "jest",
     "test:watch": "jest --onlyChanged --watch"
   },
-  "pre-commit": [
-    "test"
-  ],
   "dependencies": {
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.9.0",

--- a/scripts/ban.sh
+++ b/scripts/ban.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env sh
+# Please do not use `set -e` in this one
+
+EXCLUSION_FILE_1='package-lock.json'
+
+EXCLUSION_HTTPS='https'
+EXCLUSION_SUBSTRING='substring'
+
+FORBIDDEN=(
+  "delete props"
+  "expect(false)"
+  "expect(true)"
+  "from 'lodash'"
+  'from "lodash'
+  FunctionComponent
+  http
+  "it('should"
+  'it("should'
+  'it(`should'
+  substr
+  "'./.."
+  \"./..
+  [,
+  SFC
+  "toBe(null)"
+  "toBe(undefined)"
+  "toBeCalledTimes(0)"
+  toBeFalsy
+  toBeTruthy
+  "toEqual('"
+  'toEqual("'
+  'toEqual(`'
+  toHaveBeenCalled
+)
+
+# Test against these file types
+FILES_PATTERN='\.(css|js|json|md|ts|tsx)$'
+
+for i in "${FORBIDDEN[@]}"
+do
+  files=$(git ls-tree -r HEAD --name-only | \
+    grep -v "$EXCLUSION_FILE_1" | \
+    # Add new ones here like line above (i.e. `grep`)
+    grep -E $FILES_PATTERN
+  )
+
+  # No files matching FILES_PATTERN. Exit with success, allowing commit
+  if [ -z "$files" ]; then
+    exit 0
+  fi
+
+  # Fail commit if any contain FORBIDDEN text.
+  echo "$files" | \
+    xargs grep -v $EXCLUSION_HTTPS | \
+    grep -v $EXCLUSION_SUBSTRING | \
+    # Add new ones here like line above (i.e. `grep` without `xargs`)
+    grep --color --with-filename -n -F "$i" && \
+    echo "\n\033[0;31mFound $i references. Please remove them before committing\n" && exit 1
+done
+
+exit 0

--- a/scripts/ban.sh
+++ b/scripts/ban.sh
@@ -5,9 +5,26 @@ EXCLUSION_FILE_1='package-lock.json'
 
 EXCLUSION_HTTPS='https'
 EXCLUSION_SUBSTRING='substring'
+EXCLUSION_TO_BE_GREATER='toBeGreater'
+EXCLUSION_TO_BE_LESS='toBeLess'
 
 FORBIDDEN=(
   "delete props"
+  "Equal(0"
+  "Equal(1"
+  "Equal(2"
+  "Equal(3"
+  "Equal(4"
+  "Equal(5"
+  "Equal(6"
+  "Equal(7"
+  "Equal(8"
+  "Equal(9"
+  "Equal('"
+  'Equal("'
+  'Equal(`'
+  "Equal(false"
+  "Equal(true"
   "expect(false)"
   "expect(true)"
   "from 'lodash'"
@@ -17,6 +34,9 @@ FORBIDDEN=(
   "it('should"
   'it("should'
   'it(`should'
+  "length).to"
+  "not.toBeDefined()"
+  "not.toBeUndefined()"
   substr
   "'./.."
   \"./..
@@ -27,10 +47,8 @@ FORBIDDEN=(
   "toBeCalledTimes(0)"
   toBeFalsy
   toBeTruthy
-  "toEqual('"
-  'toEqual("'
-  'toEqual(`'
-  toHaveBeenCalled
+  toEqual
+  toHaveBeen
 )
 
 # Test against these file types
@@ -53,6 +71,8 @@ do
   echo "$files" | \
     xargs grep -v $EXCLUSION_HTTPS | \
     grep -v $EXCLUSION_SUBSTRING | \
+    grep -v $EXCLUSION_TO_BE_GREATER | \
+    grep -v $EXCLUSION_TO_BE_LESS | \
     # Add new ones here like line above (i.e. `grep` without `xargs`)
     grep --color --with-filename -n -F "$i" && \
     echo "\n\033[0;31mFound $i references. Please remove them before committing\n" && exit 1

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -e
+
+./scripts/ban.sh
+npm run test

--- a/src/components/__tests__/About.test.tsx
+++ b/src/components/__tests__/About.test.tsx
@@ -8,5 +8,5 @@ import { About } from "../About";
 it("renders without crashing", () => {
   const props = {};
   const rendered = renderer.create(<About {...props} />).toJSON();
-  expect(rendered).toBeTruthy();
+  expect(rendered).not.toBeNull();
 });

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -9,5 +9,5 @@ import { Screen } from "../../types/enum";
 it("renders without crashing", () => {
   const props = { changeScreen: jest.fn(), screen: Screen.About };
   const rendered = renderer.create(<Footer {...props} />).toJSON();
-  expect(rendered).toBeTruthy();
+  expect(rendered).not.toBeNull();
 });

--- a/src/components/__tests__/SectionListBasics.test.tsx
+++ b/src/components/__tests__/SectionListBasics.test.tsx
@@ -7,5 +7,5 @@ import { SectionListBasics } from "../SectionListBasics";
 
 it("renders without crashing", () => {
   const rendered = renderer.create(<SectionListBasics />).toJSON();
-  expect(rendered).toBeTruthy();
+  expect(rendered).not.toBeNull();
 });

--- a/src/components/__tests__/SelectedLettersText.test.tsx
+++ b/src/components/__tests__/SelectedLettersText.test.tsx
@@ -8,5 +8,5 @@ import { SelectedLettersText } from "../SelectedLettersText";
 it("renders without crashing", () => {
   const props = { style: {}, text: "" };
   const rendered = renderer.create(<SelectedLettersText {...props} />).toJSON();
-  expect(rendered).toBeTruthy();
+  expect(rendered).not.toBeNull();
 });


### PR DESCRIPTION
# Overview

**Previously,** the project had a pre-commit hook running the test suite.
**Now,** in addition to running the test suite, it also checks simple things e.g. not using `http` but `https` instead.

# Testing

- [x] `npm run test` should be ✅
- [x] App should not be affected by such changes

# Additional information

- I replaced [`pre-commit` npm module](https://www.npmjs.com/package/pre-commit) with [`husky` npm module](https://www.npmjs.com/package/husky) as `husky` had the blocking behavior I expected and is actually being maintained: it has been updated 16 days ago whereas `pre-commit` hasn't been updated for 3 years
- Once I have a bigger test suite, I'll look into better options such as https://github.com/jest-community/eslint-plugin-jest rather than bloating `ban.sh` with too many test scenarios
