### PR TITLE
😄 Add emojis next to words

### DIFF
--- a/App/index.tsx
+++ b/App/index.tsx
@@ -45,7 +45,7 @@ const App: React.FC<AppProps> = _props => {
 
   // Setup
   const isAbout = screen === Screen.About;
-  const Component = isAbout ? <About /> : <SectionListBasics letterCount={3} />;
+  const Component = isAbout ? <About /> : <SectionListBasics letterCount={4} />;
 
   // Markup
   return (

--- a/App/index.tsx
+++ b/App/index.tsx
@@ -18,7 +18,7 @@ export interface AppProps {}
 const App: React.FC<AppProps> = _props => {
   // Hooks
   const [isReady, setIsReady] = React.useState(false);
-  const [screen, setScreen] = React.useState(Screen.About);
+  const [screen, setScreen] = React.useState(Screen.Explore);
 
   // Life-cycle
   React.useEffect(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4805,6 +4805,23 @@
         }
       }
     },
+    "count-words": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/count-words/-/count-words-1.0.12.tgz",
+      "integrity": "sha512-FB3U57eQVQR9bhCISXTS0UdOri/sfToW3tfibF7xSZUugybFBf4TrAmGjjCTXmLXPMaDws56EOSB4Kx1smwA6g==",
+      "requires": {
+        "set-or-get": "^1.2.0",
+        "worder": "^1.0.0"
+      }
+    },
+    "count-words-array": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/count-words-array/-/count-words-array-1.0.12.tgz",
+      "integrity": "sha512-HcRoAVdVjVfDFS0uLeFwWzDudd5gHwjlAGl0Q2xy+AY/1Xto7jMrF3vjabFrBICvUkyzISfpe1lUJABOOZNQJg==",
+      "requires": {
+        "count-words": "^1.0.0"
+      }
+    },
     "create-ecdh": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
@@ -5308,6 +5325,14 @@
       "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==",
       "dev": true
     },
+    "deffy": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deffy/-/deffy-2.2.3.tgz",
+      "integrity": "sha512-c5JD8Z6V1aBWVzn1+aELL97R1pHCwEjXeU3hZXdigkZkxb9vhgFP162kAxGXl992TtAg0btwQyx7d54CqcQaXQ==",
+      "requires": {
+        "typpy": "^2.0.0"
+      }
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -5695,10 +5720,33 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
+    "emoji-from-text": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/emoji-from-text/-/emoji-from-text-1.1.11.tgz",
+      "integrity": "sha512-NA8CKoKxDTVc/pmhUsxhPPm10l6pTBMEICo+UoM/rhkLNvvCM51Hh4TbokwtuJpRWlI2K5YzHfL/nUHA8Fiv+g==",
+      "requires": {
+        "count-words-array": "^1.0.0",
+        "emoji-from-word": "^1.2.0"
+      }
+    },
+    "emoji-from-word": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/emoji-from-word/-/emoji-from-word-1.2.11.tgz",
+      "integrity": "sha512-RkHeAs1Rld/vNYm1Ik9RGZelRRS7mXetB+Ec/tMUNpIvndb8qBYkc0BmvSReJno2yZGfXqxH21kF0jPHmJPnfQ==",
+      "requires": {
+        "emojilib": "^1.1.0",
+        "iterate-object": "^1.3.0"
+      }
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+    },
+    "emojilib": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-1.1.0.tgz",
+      "integrity": "sha1-sXyGZ8j24yRIhxrlfQWqOwJWO4s="
     },
     "emojis-list": {
       "version": "2.1.0",
@@ -7674,6 +7722,14 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "function.name": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/function.name/-/function.name-1.0.12.tgz",
+      "integrity": "sha512-C7Tu+rAFrWW5RjXqtKtXp2xOdCujq+4i8ZH3w0uz/xrYHBwXZrPt96x8cDAEHrIjeyEv/Jm6iDGyqupbaVQTlw==",
+      "requires": {
+        "noop6": "^1.0.1"
+      }
+    },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -9293,6 +9349,11 @@
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
       "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==",
       "dev": true
+    },
+    "iterate-object": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/iterate-object/-/iterate-object-1.3.3.tgz",
+      "integrity": "sha512-DximWbkke36cnrSfNJv6bgcB2QOMV9PRD2FiowwzCoMsh8RupFLdbNIzWe+cVDWT+NIMNJgGlB1dGxP6kpzGtA=="
     },
     "jest": {
       "version": "24.9.0",
@@ -13095,6 +13156,11 @@
       "dev": true,
       "optional": true
     },
+    "noop6": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/noop6/-/noop6-1.0.8.tgz",
+      "integrity": "sha512-+Al5csMVc40I8xRfJsyBcN1IbpyvebOuQmMfxdw+AL6ECELey12ANgNTRhMfTwNIDU4W9W0g8EHLcsb3+3qPFA=="
+    },
     "normalize-css-color": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/normalize-css-color/-/normalize-css-color-1.0.2.tgz",
@@ -16727,6 +16793,14 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
+    "set-or-get": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/set-or-get/-/set-or-get-1.2.9.tgz",
+      "integrity": "sha512-G6xYWAJSs21OMBhVK/cLVi9c+jdvOoDNBxg9YBL/Y84Lyp7WVdfTWZDeflC+IQyY4IK/lijpKuiJdJySAQyXtA==",
+      "requires": {
+        "deffy": "^2.0.0"
+      }
+    },
     "set-value": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -18364,6 +18438,14 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "typpy": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/typpy/-/typpy-2.3.11.tgz",
+      "integrity": "sha512-Jh/fykZSaxeKO0ceMAs6agki9T5TNA9kiIR6fzKbvafKpIw8UlNlHhzuqKyi5lfJJ5VojJOx9tooIbyy7vHV/g==",
+      "requires": {
+        "function.name": "^1.0.3"
+      }
+    },
     "ua-parser-js": {
       "version": "0.7.20",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
@@ -19301,6 +19383,11 @@
           "dev": true
         }
       }
+    },
+    "worder": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/worder/-/worder-1.1.0.tgz",
+      "integrity": "sha512-sPICFk2lJ1CuJ2Q9Q79zP6ovNbLUKTpBj4RWKsqY90K08WJmq+/yIiukMxaPw4m128uWGGNcrFBn8AmzTfRTCw=="
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2203,6 +2203,12 @@
       "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw==",
       "dev": true
     },
+    "@types/node-emoji": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/node-emoji/-/node-emoji-1.8.1.tgz",
+      "integrity": "sha512-0fRfA90FWm6KJfw6P9QGyo0HDTCmthZ7cWaBQndITlaWLTZ6njRyKwrwpzpg+n6kBXBIGKeUHEQuBx7bphGJkA==",
+      "dev": true
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -10878,6 +10884,11 @@
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
+    "lodash.toarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
+    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -12954,6 +12965,14 @@
       "optional": true,
       "requires": {
         "semver": "^5.4.1"
+      }
+    },
+    "node-emoji": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
+      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+      "requires": {
+        "lodash.toarray": "^4.4.0"
       }
     },
     "node-fetch": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.9.0",
+    "emoji-from-text": "^1.1.11",
     "expo": "^35.0.0",
     "expo-font": "~7.0.0",
     "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "private": true,
   "devDependencies": {
     "@types/jest": "^24.0.21",
+    "@types/node-emoji": "^1.8.1",
     "@types/react": "16.8.3",
     "@types/react-native": "0.60.0",
     "@types/react-test-renderer": "16.8.3",
@@ -49,6 +50,7 @@
     "expo-font": "~7.0.0",
     "lodash": "^4.17.15",
     "native-base": "^2.13.8",
+    "node-emoji": "^1.10.0",
     "react": "16.8.3",
     "react-dom": "16.8.3",
     "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",

--- a/scripts/ban.sh
+++ b/scripts/ban.sh
@@ -28,7 +28,7 @@ FORBIDDEN=(
   "expect(false)"
   "expect(true)"
   "from 'lodash'"
-  'from "lodash'
+  'from "lodash"'
   FunctionComponent
   http
   "it('should"

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -34,9 +34,12 @@ const About: React.FC<AboutProps> = _props => {
     );
   };
 
-  const libraries = ["native-base", "node-emoji", "react-native"].map(v =>
-    renderLibrary(v)
-  );
+  const libraries = [
+    "emoji-from-text",
+    "native-base",
+    "node-emoji",
+    "react-native"
+  ].map(v => renderLibrary(v));
 
   return (
     <Container>

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -34,7 +34,9 @@ const About: React.FC<AboutProps> = _props => {
     );
   };
 
-  const libraries = ["native-base", "react-native"].map(v => renderLibrary(v));
+  const libraries = ["native-base", "node-emoji", "react-native"].map(v =>
+    renderLibrary(v)
+  );
 
   return (
     <Container>

--- a/src/components/Emoji.tsx
+++ b/src/components/Emoji.tsx
@@ -14,9 +14,7 @@ const Emoji: React.FC<EmojiProps> = props => {
   const { text } = props;
 
   const emojiObject = emoji.find(text);
-  const fallbackEmojiObject = emoji.search(text);
-  const fallbackEmojiIcon = get(fallbackEmojiObject, "[0].emoji", null);
-  const emojiIcon = emojiObject ? emojiObject.emoji : fallbackEmojiIcon;
+  const emojiIcon = emojiObject ? emojiObject.emoji : null;
 
   // Short-circuit
   if (!emojiIcon) return null;

--- a/src/components/Emoji.tsx
+++ b/src/components/Emoji.tsx
@@ -1,0 +1,20 @@
+// Vendor
+import * as emoji from "node-emoji";
+import * as React from "react";
+import { Text } from "react-native";
+
+export interface EmojiProps {
+  style: any;
+  text: string;
+}
+
+const Emoji: React.FC<EmojiProps> = props => {
+  const { text } = props;
+
+  const emojiObject = emoji.find(text);
+  const emojiIcon = emojiObject ? emojiObject.emoji : undefined;
+
+  return <Text>{emojiIcon}</Text>;
+};
+
+export { Emoji };

--- a/src/components/Emoji.tsx
+++ b/src/components/Emoji.tsx
@@ -1,7 +1,8 @@
 // Vendor
 import * as emoji from "node-emoji";
-import emojiFromText from "emoji-from-text";
 import * as React from "react";
+import emojiFromText from "emoji-from-text";
+import get from "lodash/get";
 import { Text } from "react-native";
 
 export interface EmojiProps {
@@ -19,19 +20,8 @@ const Emoji: React.FC<EmojiProps> = props => {
   // Short-circuit
   if (emojiIcon) return <Text>{emojiIcon}</Text>;
 
-  const emojiFallbackTemp = (emojiFromText as any)(text, true);
-  const emojiFallbackTemp2 = emojiFallbackTemp ? emojiFallbackTemp.match : null;
-  const emojiFallbackTemp3 = emojiFallbackTemp2
-    ? emojiFallbackTemp2.toString()
-    : null;
-
-  const emojiFallbackTemp4 = emojiFallbackTemp3
-    ? emoji.find(emojiFallbackTemp3)
-    : null;
-
-  const emojiFallbackIcon = emojiFallbackTemp4
-    ? emojiFallbackTemp4.emoji
-    : null;
+  const emojiFallbackTemp = emojiFromText(text, true);
+  const emojiFallbackIcon = get(emojiFallbackTemp, "match.emoji.char");
 
   return emojiFallbackIcon ? <Text>{emojiFallbackIcon}</Text> : null;
 };

--- a/src/components/Emoji.tsx
+++ b/src/components/Emoji.tsx
@@ -1,7 +1,7 @@
 // Vendor
 import * as emoji from "node-emoji";
+import emojiFromText from "emoji-from-text";
 import * as React from "react";
-import get from "lodash/get";
 import { Text } from "react-native";
 
 export interface EmojiProps {
@@ -17,9 +17,23 @@ const Emoji: React.FC<EmojiProps> = props => {
   const emojiIcon = emojiObject ? emojiObject.emoji : null;
 
   // Short-circuit
-  if (!emojiIcon) return null;
+  if (emojiIcon) return <Text>{emojiIcon}</Text>;
 
-  return <Text>{emojiIcon}</Text>;
+  const emojiFallbackTemp = (emojiFromText as any)(text, true);
+  const emojiFallbackTemp2 = emojiFallbackTemp ? emojiFallbackTemp.match : null;
+  const emojiFallbackTemp3 = emojiFallbackTemp2
+    ? emojiFallbackTemp2.toString()
+    : null;
+
+  const emojiFallbackTemp4 = emojiFallbackTemp3
+    ? emoji.find(emojiFallbackTemp3)
+    : null;
+
+  const emojiFallbackIcon = emojiFallbackTemp4
+    ? emojiFallbackTemp4.emoji
+    : null;
+
+  return emojiFallbackIcon ? <Text>{emojiFallbackIcon}</Text> : null;
 };
 
 export { Emoji };

--- a/src/components/Emoji.tsx
+++ b/src/components/Emoji.tsx
@@ -1,6 +1,7 @@
 // Vendor
 import * as emoji from "node-emoji";
 import * as React from "react";
+import get from "lodash/get";
 import { Text } from "react-native";
 
 export interface EmojiProps {
@@ -9,10 +10,16 @@ export interface EmojiProps {
 }
 
 const Emoji: React.FC<EmojiProps> = props => {
+  // Setup
   const { text } = props;
 
   const emojiObject = emoji.find(text);
-  const emojiIcon = emojiObject ? emojiObject.emoji : undefined;
+  const fallbackEmojiObject = emoji.search(text);
+  const fallbackEmojiIcon = get(fallbackEmojiObject, "[0].emoji", null);
+  const emojiIcon = emojiObject ? emojiObject.emoji : fallbackEmojiIcon;
+
+  // Short-circuit
+  if (!emojiIcon) return null;
 
   return <Text>{emojiIcon}</Text>;
 };

--- a/src/components/SectionListBasics.tsx
+++ b/src/components/SectionListBasics.tsx
@@ -8,12 +8,14 @@ import { pluralize } from "../helpers/strings";
 import { SelectedLettersText } from "./SelectedLettersText";
 
 /*
+  TODO: fix if possible
   React-native does not support dynamic imports apparently
   See https://github.com/facebook/react-native/issues/2481#issuecomment-299074154
 */
 const DATA: any = {
   letterCountIs2: require("../data/words/2-letters.json"),
-  letterCountIs3: require("../data/words/3-letters.json")
+  letterCountIs3: require("../data/words/3-letters.json"),
+  letterCountIs4: require("../data/words/4-letters.json")
 };
 
 export interface SectionListBasicsProps {

--- a/src/components/SectionListBasics.tsx
+++ b/src/components/SectionListBasics.tsx
@@ -1,9 +1,9 @@
 // Vendor
-import * as emoji from "node-emoji";
 import * as React from "react";
 import { SectionList, StyleSheet, Text, TextInput, View } from "react-native";
 
 // Internal
+import { Emoji } from "./Emoji";
 import { pluralize } from "../helpers/strings";
 import { SelectedLettersText } from "./SelectedLettersText";
 
@@ -89,12 +89,9 @@ const SectionListBasics: React.FC<SectionListBasicsProps> = props => {
         <SectionList
           sections={xLetterWordsSections}
           renderItem={({ item }) => {
-            const emojiObject = emoji.find(item);
-            const emojiIcon = emojiObject ? emojiObject.emoji : undefined;
-
             return (
               <View style={styles.inlineWrapper}>
-                {emojiIcon && <Text style={styles.emoji}>{emojiIcon}</Text>}
+                <Emoji style={styles.emoji} text={item} />
                 <SelectedLettersText
                   letters={occurrencesLetters}
                   style={styles.item}

--- a/src/components/SectionListBasics.tsx
+++ b/src/components/SectionListBasics.tsx
@@ -1,4 +1,5 @@
 // Vendor
+import * as emoji from "node-emoji";
 import * as React from "react";
 import { SectionList, StyleSheet, Text, TextInput, View } from "react-native";
 
@@ -32,6 +33,7 @@ const SectionListBasics: React.FC<SectionListBasicsProps> = props => {
           wordObject.englishWord.toLowerCase().includes(searchText)
         )
       : jsonObject;
+
     const allSortedWords: any[] = [];
     let currentGroupOfWords: any = [];
     let currentLetter = 97;
@@ -86,13 +88,21 @@ const SectionListBasics: React.FC<SectionListBasicsProps> = props => {
       {xLetterWordsSections.length ? (
         <SectionList
           sections={xLetterWordsSections}
-          renderItem={({ item }) => (
-            <SelectedLettersText
-              letters={occurrencesLetters}
-              style={styles.item}
-              text={item}
-            />
-          )}
+          renderItem={({ item }) => {
+            const emojiObject = emoji.find(item);
+            const emojiIcon = emojiObject ? emojiObject.emoji : undefined;
+
+            return (
+              <View style={styles.inlineWrapper}>
+                {emojiIcon && <Text style={styles.emoji}>{emojiIcon}</Text>}
+                <SelectedLettersText
+                  letters={occurrencesLetters}
+                  style={styles.item}
+                  text={item}
+                />
+              </View>
+            );
+          }}
           renderSectionHeader={({ section }) => (
             <Text style={styles.sectionHeader}>{section.title}</Text>
           )}
@@ -118,6 +128,13 @@ SectionListBasics.defaultProps = {
 const styles = StyleSheet.create({
   container: {
     flex: 1
+  },
+  emoji: {
+    paddingTop: 4
+  },
+  inlineWrapper: {
+    flex: 1,
+    flexDirection: "row"
   },
   searchBar: {
     fontSize: 16,
@@ -146,9 +163,7 @@ const styles = StyleSheet.create({
     backgroundColor: "black"
   },
   item: {
-    padding: 10,
-    fontSize: 18,
-    height: 44
+    fontSize: 18
   }
 });
 

--- a/src/components/SelectedLettersText.tsx
+++ b/src/components/SelectedLettersText.tsx
@@ -39,11 +39,11 @@ const styles = StyleSheet.create({
   },
   inlineWrapper: {
     flex: 1,
-    flexDirection: "row"
+    flexDirection: "row",
+    fontSize: 18
   },
   textStyle: {
-    fontSize: 18,
-    height: 44
+    fontSize: 18
   }
 });
 

--- a/src/components/__tests__/Emoji.test.tsx
+++ b/src/components/__tests__/Emoji.test.tsx
@@ -1,0 +1,12 @@
+// Vendor
+import React from "react";
+import renderer from "react-test-renderer";
+
+// Internal
+import { Emoji } from "../Emoji";
+
+it("renders without crashing", () => {
+  const props = { style: {}, text: "pizza" };
+  const rendered = renderer.create(<Emoji {...props} />).toJSON();
+  expect(rendered).not.toBeNull();
+});

--- a/src/data/words/4-letters.json
+++ b/src/data/words/4-letters.json
@@ -1,0 +1,2134 @@
+[
+  {
+    "englishWord": "able",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "ache",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "aids",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "alas",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "also",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "arab",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "area",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "army",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "aunt",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "babe",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "baby",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "back",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "bake",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "bald",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "ball",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "band",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "bang",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "bank",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "bath",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "bean",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "bear",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "beat",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "beer",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "belt",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "bend",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "best",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "bike",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "bind",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "bird",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "bite",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "blow",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "blue",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "boat",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "body",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "bold",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "bomb",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "bone",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "book",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "boot",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "both",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "bowl",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "burn",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "bust",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "busy",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "cage",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "cake",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "call",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "calm",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "card",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "care",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "carp",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "case",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "cast",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "cave",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "cell",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "chip",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "city",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "club",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "clue",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "coal",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "coat",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "cock",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "code",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "coke",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "cold",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "come",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "cook",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "cool",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "cord",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "cost",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "coup",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "crap",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "crew",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "crow",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "cute",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "dale",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "dare",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "dark",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "data",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "date",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "dead",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "deal",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "dear",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "debt",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "deep",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "deny",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "desk",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "dial",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "dice",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "dirt",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "disc",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "disk",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "dive",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "dock",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "doll",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "door",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "down",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "draw",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "drop",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "drug",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "duck",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "dumb",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "dust",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "duty",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "each",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "earl",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "earn",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "easy",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "even",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "ever",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "evil",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "exit",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "face",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "fact",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "fail",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "fair",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "fake",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "fall",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "fame",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "fast",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "fate",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "fear",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "feed",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "feel",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "feet",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "file",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "fill",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "find",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "fine",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "fire",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "fish",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "five",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "flag",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "flat",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "flee",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "folk",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "food",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "fool",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "foot",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "fork",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "fort",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "four",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "free",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "frog",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "from",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "fuck",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "full",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "game",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "gang",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "gate",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "gift",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "gild",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "gird",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "girl",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "give",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "glad",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "goal",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "gold",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "good",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "gray",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "grey",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "grow",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hair",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "half",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hand",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hang",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hard",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "harm",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hate",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "have",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "head",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "heal",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hear",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "heat",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hell",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "help",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "here",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hero",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hide",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "high",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hill",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hint",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hire",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hold",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hole",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "holy",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hood",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hoof",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hook",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hope",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "horn",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hour",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "huge",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hunt",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "hurt",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "icon",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "idea",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "idle",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "into",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "iron",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "item",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "jail",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "jerk",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "join",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "joke",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "just",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "kart",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "keep",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "kick",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "kill",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "kind",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "king",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "kiss",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "knee",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "knit",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "know",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lack",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lade",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lady",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lake",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lamb",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lamp",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "land",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "last",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "late",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lazy",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lead",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "leaf",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lean",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "leap",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "left",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lend",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "less",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "life",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lift",
+    "frenchWord": "ascenseur"
+  },
+  {
+    "englishWord": "like",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "line",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "link",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lion",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "list",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "live",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "loan",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lock",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "long",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "look",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "loop",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lord",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lose",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "loud",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "love",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "luck",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lung",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lust",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lyre",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "maid",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "mail",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "make",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "male",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "mama",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "mane",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "many",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "mare",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "mark",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "mask",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "mate",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "maze",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "meal",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "mean",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "meat",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "meet",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "melt",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "mend",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "mike",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "mild",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "milk",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "mind",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "mine",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "miss",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "mood",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "moon",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "more",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "move",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "much",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "must",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "mutt",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "nail",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "name",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "near",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "neck",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "need",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "news",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "next",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "nice",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "nine",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "noon",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "nope",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "nose",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "note",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "nuke",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "obey",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "odor",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "oily",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "okay",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "once",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "only",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "open",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "oven",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "over",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "pace",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "page",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "pain",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "pale",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "park",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "part",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "past",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "path",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "pear",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "pick",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "pier",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "pink",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "pipe",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "pity",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "plan",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "play",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "poem",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "pony",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "pool",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "poor",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "pork",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "port",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "post",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "pour",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "pull",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "pure",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "push",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "quit",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "race",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "rail",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "rain",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "ramp",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "rape",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "rate",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "raze",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "read",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "real",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "rend",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "rent",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "rest",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "rice",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "rich",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "ride",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "ring",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "rise",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "risk",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "road",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "rock",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "role",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "roll",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "roof",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "room",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "root",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "rule",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "rush",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "sack",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "safe",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "salt",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "same",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "save",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "seat",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "seek",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "seem",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "self",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "sell",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "send",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "shed",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "ship",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "shit",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "shoe",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "shop",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "shot",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "show",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "shut",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "sick",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "side",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "sing",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "sink",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "size",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "skin",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "skip",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "slay",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "slit",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "slot",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "slow",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "snap",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "snow",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "soft",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "some",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "song",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "soon",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "sort",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "soup",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "spin",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "spit",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "spot",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "star",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "stay",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "step",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "stop",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "suck",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "suit",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "sure",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "swap",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "swim",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "tail",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "take",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "talk",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "tall",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "tank",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "tart",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "task",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "taxi",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "team",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "tear",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "teen",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "tell",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "tend",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "test",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "text",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "that",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "then",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "they",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "thin",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "thug",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "tidy",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "tile",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "time",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "tire",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "toad",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "toll",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "tome",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "tone",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "tool",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "town",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "trap",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "tree",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "trip",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "TRUE",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "tube",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "tuna",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "tune",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "turn",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "tyre",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "ugly",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "undo",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "unit",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "urge",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "user",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "very",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "vine",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "void",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "wait",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "wake",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "walk",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "wall",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "want",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "warm",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "warn",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "wash",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "wave",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "weak",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "wear",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "week",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "weep",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "well",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "what",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "when",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "wide",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "wife",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "wild",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "wind",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "wine",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "wing",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "wink",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "wire",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "wise",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "wish",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "with",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "wood",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "word",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "work",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "yard",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "yeah",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "year",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "yell",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "your",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "zero",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "zoom",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "bays",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "lame",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "soar",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "grin",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "quad",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "nude",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "cyan",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "teal",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "navy",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "rose",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "arch",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "oval",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "whim",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "IMHO",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "JSYK",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "thks",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "TTYL",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "NSFW",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "YOLO",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "BYOB",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "ASAP",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "RSVP",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "RTFM",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "TGIF",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "June",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "July",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "auto",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "cart",
+    "frenchWord": "charrette"
+  },
+  {
+    "englishWord": "robe",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "jeep",
+    "frenchWord": "jeep"
+  },
+  {
+    "englishWord": "vest",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "ves*",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "cuff",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "west",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "east",
+    "frenchWord": ""
+  },
+  {
+    "englishWord": "dish",
+    "frenchWord": ""
+  }
+]

--- a/src/types/modules.d.ts
+++ b/src/types/modules.d.ts
@@ -1,0 +1,4 @@
+declare module "emoji-from-text" {
+  function emojiFromText(text: string, onlyOneMatch?: boolean): any;
+  export = emojiFromText;
+}


### PR DESCRIPTION
# Overview

**Previously,** words were text-only.
**Now,** a small emoji appears next to them.

<details><summary>Screenshot</summary>

![IMG_9524](https://user-images.githubusercontent.com/25478895/68520751-a84c1900-029a-11ea-84d1-7a514fdba211.PNG)

</details>

# Testing

- [x] `npm run test` should be ✅
- [x] App should be available on a real device (iPhone) after running `npm run start`
- [x] Emojis should be visible

# Additional information

- Some emojis are not perfect but this is good enough for a first iteration
- I used `node-emoji` (which has ~1 million weekly downloads) and `emoji-from-text` as a fallback (hardly downloaded but offers good alternatives)
- As part of testing it, I also added 4-letter words from the spreadsheet to the app
