### PR TITLE
🔧 Fix recently introduced code regressions

### DIFF
--- a/App/__tests__/__snapshots__/index.test.tsx.snap
+++ b/App/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,869 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders 1`] = `
+Array [
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#fff",
+          "flex": 1,
+          "height": 1334,
+        },
+        Object {
+          "backgroundColor": "#fff",
+          "flex": 1,
+          "paddingTop": 25,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "flex": 1,
+          "height": 1334,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "textAlign": "center",
+          }
+        }
+      >
+        Game
+      </Text>
+      <View
+        style={
+          Object {
+            "flex": 3,
+            "flexDirection": "column",
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+        </View>
+        <View
+          style={
+            Object {
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+        </View>
+        <View
+          style={
+            Object {
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+        </View>
+        <View
+          style={
+            Object {
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+        </View>
+        <View
+          style={
+            Object {
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+        </View>
+        <View
+          style={
+            Object {
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flex": 1,
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "fontSize": 30,
+                  }
+                }
+              >
+                s
+              </Text>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flex": 1,
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "fontSize": 30,
+                  }
+                }
+              >
+                p
+              </Text>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flex": 1,
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "fontSize": 30,
+                  }
+                }
+              >
+                l
+              </Text>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flex": 1,
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "fontSize": 30,
+                  }
+                }
+              >
+                a
+              </Text>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flex": 1,
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "fontSize": 30,
+                  }
+                }
+              >
+                s
+              </Text>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flex": 1,
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "fontSize": 30,
+                  }
+                }
+              >
+                h
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "yellow",
+            "flex": 1,
+          }
+        }
+      >
+        <Text>
+          Example
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "backgroundColor": "#F8F8F8",
+          "borderColor": "#cbcbcb",
+          "borderTopWidth": 0.5,
+          "elevation": 3,
+          "flexDirection": "row",
+          "height": 55,
+          "justifyContent": "center",
+          "left": 0,
+          "paddingBottom": 0,
+          "right": 0,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignSelf": "stretch",
+            "backgroundColor": undefined,
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+          }
+        }
+      >
+        <TouchableOpacity
+          active={false}
+          activeOpacity={0.5}
+          style={
+            Object {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "backgroundColor": "transparent",
+              "borderBottomWidth": null,
+              "borderColor": null,
+              "borderLeftWidth": null,
+              "borderRadius": 5,
+              "borderRightWidth": null,
+              "borderTopWidth": null,
+              "borderWidth": undefined,
+              "elevation": 0,
+              "flex": 1,
+              "flexDirection": "column",
+              "height": null,
+              "justifyContent": "center",
+              "paddingBottom": 6,
+              "paddingTop": 6,
+              "shadowColor": null,
+              "shadowOffset": null,
+              "shadowOpacity": null,
+              "shadowRadius": null,
+            }
+          }
+          vertical={true}
+        >
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": undefined,
+                  "fontSize": 12,
+                },
+                Array [
+                  Object {
+                    "color": "#000",
+                    "fontSize": 30,
+                  },
+                  Object {
+                    "color": "#6b6b6b",
+                    "fontSize": 24,
+                    "marginLeft": 16,
+                    "marginRight": 16,
+                    "paddingTop": 2,
+                  },
+                ],
+                Object {
+                  "fontFamily": "Ionicons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+          <Text
+            style={
+              Object {
+                "backgroundColor": "transparent",
+                "color": "#6b6b6b",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "lineHeight": 16,
+                "marginLeft": 0,
+                "marginRight": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+              }
+            }
+            uppercase={false}
+          >
+            Explore
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          active={true}
+          activeOpacity={0.5}
+          style={
+            Object {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "backgroundColor": "#cde1f9",
+              "borderBottomWidth": null,
+              "borderColor": null,
+              "borderLeftWidth": null,
+              "borderRadius": 5,
+              "borderRightWidth": null,
+              "borderTopWidth": null,
+              "borderWidth": undefined,
+              "elevation": 0,
+              "flex": 1,
+              "flexDirection": "column",
+              "height": null,
+              "justifyContent": "center",
+              "paddingBottom": 6,
+              "paddingTop": 6,
+              "shadowColor": null,
+              "shadowOffset": null,
+              "shadowOpacity": null,
+              "shadowRadius": null,
+            }
+          }
+          vertical={true}
+        >
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": undefined,
+                  "fontSize": 12,
+                },
+                Array [
+                  Object {
+                    "color": "#000",
+                    "fontSize": 30,
+                  },
+                  Object {
+                    "color": "#007aff",
+                    "fontSize": 24,
+                    "marginLeft": 16,
+                    "marginRight": 16,
+                    "paddingTop": 2,
+                  },
+                ],
+                Object {
+                  "fontFamily": "Ionicons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+          <Text
+            style={
+              Object {
+                "backgroundColor": "transparent",
+                "color": "#007aff",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "lineHeight": 16,
+                "marginLeft": 0,
+                "marginRight": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+              }
+            }
+            uppercase={false}
+          >
+            Play
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          active={false}
+          activeOpacity={0.5}
+          style={
+            Object {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "backgroundColor": "transparent",
+              "borderBottomWidth": null,
+              "borderColor": null,
+              "borderLeftWidth": null,
+              "borderRadius": 5,
+              "borderRightWidth": null,
+              "borderTopWidth": null,
+              "borderWidth": undefined,
+              "elevation": 0,
+              "flex": 1,
+              "flexDirection": "column",
+              "height": null,
+              "justifyContent": "center",
+              "paddingBottom": 6,
+              "paddingTop": 6,
+              "shadowColor": null,
+              "shadowOffset": null,
+              "shadowOpacity": null,
+              "shadowRadius": null,
+            }
+          }
+          vertical={true}
+        >
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": undefined,
+                  "fontSize": 12,
+                },
+                Array [
+                  Object {
+                    "color": "#000",
+                    "fontSize": 30,
+                  },
+                  Object {
+                    "color": "#6b6b6b",
+                    "fontSize": 24,
+                    "marginLeft": 16,
+                    "marginRight": 16,
+                    "paddingTop": 2,
+                  },
+                ],
+                Object {
+                  "fontFamily": "Ionicons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+          <Text
+            style={
+              Object {
+                "backgroundColor": "transparent",
+                "color": "#6b6b6b",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "lineHeight": 16,
+                "marginLeft": 0,
+                "marginRight": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+              }
+            }
+            uppercase={false}
+          >
+            About
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  </View>,
+]
+`;

--- a/App/__tests__/index.test.tsx
+++ b/App/__tests__/index.test.tsx
@@ -1,15 +1,17 @@
 // Mocks
-jest.mock("expo-constants", () => ({ manifest: { version: "1.2.3" } }));
+jest.mock("expo", () => ({ AppLoading: "AppLoading" }));
+jest.mock("@expo/vector-icons", () => ({}));
 
 // Vendor
 import React from "react";
 import { render } from "@testing-library/react-native";
 
 // Internal
-import { About } from "../About";
+import App from "../index";
 
 it("renders", () => {
-  const { container } = render(<About />);
+  const props = { initialReady: true };
+  const { container } = render(<App {...props} />);
   expect(container.children.length).toBeGreaterThan(0);
   expect(container.children).toMatchSnapshot();
 });

--- a/App/__tests__/index.test.tsx
+++ b/App/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
 // Mocks
-jest.mock("expo", () => ({ AppLoading: "AppLoading" }));
+jest.mock("expo", () => ({}));
 jest.mock("@expo/vector-icons", () => ({}));
 
 // Vendor

--- a/App/index.tsx
+++ b/App/index.tsx
@@ -14,11 +14,16 @@ import { Results } from "../src/components/Results";
 import { Screen } from "../src/types/enum";
 import { HEADER_Y } from "../src/config/settings";
 
-export interface AppProps {}
+export interface AppProps {
+  initialReady?: boolean;
+}
 
-const App: React.FC<AppProps> = _props => {
+const App: React.FC<AppProps> = props => {
+  // Setup
+  const { initialReady } = props;
+
   // Hooks
-  const [isReady, setIsReady] = React.useState(false);
+  const [isReady, setIsReady] = React.useState(initialReady);
   const [screen, setScreen] = React.useState(Screen.Game);
 
   // Life-cycle
@@ -58,6 +63,10 @@ const App: React.FC<AppProps> = _props => {
       <Footer changeScreen={changeScreen} screen={screen} />
     </Container>
   );
+};
+
+App.defaultProps = {
+  initialReady: false
 };
 
 const styles = StyleSheet.create({

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
       "|@unimodules" +
       "|expo" +
       "|expo-asset" +
+      "|expo-constants" +
       "|expo-file-system" +
       "|expo-font" +
       "|expo-location" +

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "emoji-from-text": "^1.1.11",
     "expo": "^36.0.0",
-    "expo-constants": "~8.0.0",
+    "expo-constants": "^8.0.0",
     "expo-font": "~8.0.0",
     "lodash": "^4.17.15",
     "native-base": "^2.13.8",

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -12,6 +12,8 @@ import {
   Text,
   Thumbnail
 } from "native-base";
+import Constants from "expo-constants";
+import get from "lodash/get";
 import { Linking, StyleSheet } from "react-native";
 
 export interface AboutProps {}
@@ -22,6 +24,7 @@ const About: React.FC<AboutProps> = _props => {
   const authorAvatar = "https://avatars1.githubusercontent.com/u/25478895";
   const authorUrl = `https://github.com/${author}`;
   const currentYear = new Date(Date.now()).getFullYear();
+  const version = get(Constants, "manifest.version", "unknown");
 
   const renderLibrary = (library: string) => {
     return (
@@ -51,7 +54,7 @@ const About: React.FC<AboutProps> = _props => {
             <Text>{`Created in 2018 - ${currentYear}`}</Text>
           </ListItem>
           <ListItem>
-            <Text>{`Version 1.0.0`}</Text>
+            <Text>{`Version ${version}`}</Text>
           </ListItem>
           <ListItem
             onPress={() => {

--- a/src/components/__tests__/About.test.tsx
+++ b/src/components/__tests__/About.test.tsx
@@ -1,3 +1,6 @@
+// Mocks
+jest.mock("expo-constants", () => ({ manifest: { version: "1.2.3" } }));
+
 // Vendor
 import React from "react";
 import { render } from "@testing-library/react-native";

--- a/src/components/__tests__/__snapshots__/About.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/About.test.tsx.snap
@@ -150,7 +150,7 @@ Array [
               }
               uppercase={false}
             >
-              Version 1.0.0
+              Version 1.2.3
             </Text>
           </View>
         </TouchableHighlight>


### PR DESCRIPTION
# Overview

**Previously,** two regressions were introduced as a compromise:
- https://github.com/sebranly/WordyWorld/pull/42#issuecomment-575970017
- https://github.com/sebranly/WordyWorld/pull/42#issuecomment-575971745

**Now,** both regressions are fixed.

# Testing

- [x] `npm run test` should be ✅
- [x] App should be available on a real device (iPhone) after running `npm run start`

# Additional information

For `App/index.tsx` I decided to use an `initialReady` props only for tests (so it's set to `false` if not present, for same behavior as what the app used to do). I could also have added an `&& process.env['NODE_ENV'] !== 'test'` condition to the short-circuit (instead) but I find it a bit dirty. Reason behind all of it is that it looks difficult to simulate `useEffect` with `react-native` + the testing library (note: I tried out `rerender` to no luck): https://github.com/testing-library/react-testing-library/issues/215
