### PR TITLE
🔡  Word helpers

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -2,4 +2,3 @@
 set -e
 
 ./scripts/ban.sh
-npm run test

--- a/src/helpers/__tests__/strings.test.ts
+++ b/src/helpers/__tests__/strings.test.ts
@@ -2,6 +2,7 @@
 import {
   areAnagrams,
   decomposeWord,
+  findAdditionWordConnections,
   findWordConnections,
   pluralize
 } from "../strings";
@@ -11,6 +12,7 @@ describe("strings helper", () => {
   it("exports the following helpers", () => {
     expect(typeof areAnagrams).toBe("function");
     expect(typeof decomposeWord).toBe("function");
+    expect(typeof findAdditionWordConnections).toBe("function");
     expect(typeof findWordConnections).toBe("function");
     expect(typeof pluralize).toBe("function");
   });
@@ -79,6 +81,67 @@ describe("strings helper", () => {
     it("handles words with a letter appearing several times", () => {
       result = decomposeWord("attack");
       expect(result).toStrictEqual({ a: 2, t: 2, c: 1, k: 1 });
+    });
+  });
+
+  describe("findAdditionWordConnections", () => {
+    // TODO: fix any
+    let result: any;
+
+    it("returns empty if any string is empty", () => {
+      result = findAdditionWordConnections("", "");
+      expect(result).toStrictEqual([]);
+
+      result = findAdditionWordConnections("a", "");
+      expect(result).toStrictEqual([]);
+
+      result = findAdditionWordConnections("", "a");
+      expect(result).toStrictEqual([]);
+    });
+
+    it("returns empty if same word is provided", () => {
+      result = findAdditionWordConnections("a", "a");
+      expect(result).toStrictEqual([]);
+    });
+
+    it("returns connections when applicable", () => {
+      result = findAdditionWordConnections("earth", "hearth");
+      expect(result).toStrictEqual([
+        { character: "h", position: 0, type: WordConnection.Addition }
+      ]);
+
+      result = findAdditionWordConnections("heart", "hearth");
+      expect(result).toStrictEqual([
+        { character: "h", position: 5, type: WordConnection.Addition }
+      ]);
+
+      result = findAdditionWordConnections("ten", "then");
+      expect(result).toStrictEqual([
+        {
+          character: "h",
+          position: 1,
+          type: WordConnection.Addition
+        }
+      ]);
+
+      result = findAdditionWordConnections("god", "good");
+      expect(result).toStrictEqual([
+        {
+          character: "o",
+          position: 1,
+          type: WordConnection.Addition
+        },
+        {
+          character: "o",
+          position: 2,
+          type: WordConnection.Addition
+        }
+      ]);
+    });
+
+    it("returns empty if no word connection", () => {
+      result = findAdditionWordConnections("word", "sentence");
+      expect(result).toStrictEqual([]);
     });
   });
 

--- a/src/helpers/__tests__/strings.test.ts
+++ b/src/helpers/__tests__/strings.test.ts
@@ -1,10 +1,58 @@
 // Internal
-import { decomposeWord, pluralize } from "../strings";
+import { areAnagrams, decomposeWord, pluralize } from "../strings";
 
 describe("strings helper", () => {
   it("exports the following helpers", () => {
+    expect(typeof areAnagrams).toBe("function");
     expect(typeof decomposeWord).toBe("function");
     expect(typeof pluralize).toBe("function");
+  });
+
+  describe("areAnagrams", () => {
+    let result: boolean;
+
+    it("returns false if any string is empty", () => {
+      result = areAnagrams("", "");
+      expect(result).toBe(false);
+
+      result = areAnagrams("", "a");
+      expect(result).toBe(false);
+
+      result = areAnagrams("a", "");
+      expect(result).toBe(false);
+    });
+
+    it("returns false if same string is provided twice", () => {
+      result = areAnagrams("word", "word");
+      expect(result).toBe(false);
+    });
+
+    it("returns true if words are anagrams", () => {
+      result = areAnagrams("dog", "god");
+      expect(result).toBe(true);
+
+      result = areAnagrams("chien", "niche");
+      expect(result).toBe(true);
+    });
+
+    it("returns false if the letters are different", () => {
+      result = areAnagrams("rap", "dog");
+      expect(result).toBe(false);
+
+      result = areAnagrams("mouse", "house");
+      expect(result).toBe(false);
+
+      result = areAnagrams("word", "house");
+      expect(result).toBe(false);
+
+      // Notice how all letters of 'dog' appears in 'good'
+      result = areAnagrams("dog", "good");
+      expect(result).toBe(false);
+
+      // Notice how all letters of 'dog' appears in 'dogs'
+      result = areAnagrams("dog", "dogs");
+      expect(result).toBe(false);
+    });
   });
 
   describe("decomposeWord", () => {

--- a/src/helpers/__tests__/strings.test.ts
+++ b/src/helpers/__tests__/strings.test.ts
@@ -270,9 +270,30 @@ describe("strings helper", () => {
       expect(result).toStrictEqual([{ type: WordConnection.Same }]);
     });
 
-    it("returns Anagram is words are anagrams", () => {
+    it("returns Anagram when applicable", () => {
       result = findWordConnections("dog", "god");
       expect(result).toStrictEqual([{ type: WordConnection.Anagram }]);
+    });
+
+    it("returns Addition when applicable", () => {
+      result = findWordConnections("ten", "then");
+      expect(result).toStrictEqual([
+        { character: "h", position: 1, type: WordConnection.Addition }
+      ]);
+    });
+
+    it("returns Deletion when applicable", () => {
+      result = findWordConnections("then", "ten");
+      expect(result).toStrictEqual([
+        { position: 1, type: WordConnection.Deletion }
+      ]);
+    });
+
+    it("returns Replacement when applicable", () => {
+      result = findWordConnections("bar", "car");
+      expect(result).toStrictEqual([
+        { character: "c", position: 0, type: WordConnection.Replacement }
+      ]);
     });
 
     it("returns empty if no word connection", () => {

--- a/src/helpers/__tests__/strings.test.ts
+++ b/src/helpers/__tests__/strings.test.ts
@@ -1,7 +1,32 @@
 // Internal
-import { pluralize } from "../strings";
+import { decomposeWord, pluralize } from "../strings";
 
 describe("strings helper", () => {
+  it("exports the following helpers", () => {
+    expect(typeof decomposeWord).toBe("function");
+    expect(typeof pluralize).toBe("function");
+  });
+
+  describe("decomposeWord", () => {
+    // TODO: fix any
+    let result: any;
+
+    it("returns empty object for empty string", () => {
+      result = decomposeWord("");
+      expect(result).toStrictEqual({});
+    });
+
+    it("returns object with letters", () => {
+      result = decomposeWord("word");
+      expect(result).toStrictEqual({ w: 1, o: 1, r: 1, d: 1 });
+    });
+
+    it("handles words with a letter appearing several times", () => {
+      result = decomposeWord("attack");
+      expect(result).toStrictEqual({ a: 2, t: 2, c: 1, k: 1 });
+    });
+  });
+
   describe("pluralize", () => {
     let result: string;
 

--- a/src/helpers/__tests__/strings.test.ts
+++ b/src/helpers/__tests__/strings.test.ts
@@ -1,10 +1,17 @@
 // Internal
-import { areAnagrams, decomposeWord, pluralize } from "../strings";
+import {
+  areAnagrams,
+  decomposeWord,
+  findWordConnections,
+  pluralize
+} from "../strings";
+import { WordConnection } from "../../types/enum";
 
 describe("strings helper", () => {
   it("exports the following helpers", () => {
     expect(typeof areAnagrams).toBe("function");
     expect(typeof decomposeWord).toBe("function");
+    expect(typeof findWordConnections).toBe("function");
     expect(typeof pluralize).toBe("function");
   });
 
@@ -72,6 +79,40 @@ describe("strings helper", () => {
     it("handles words with a letter appearing several times", () => {
       result = decomposeWord("attack");
       expect(result).toStrictEqual({ a: 2, t: 2, c: 1, k: 1 });
+    });
+  });
+
+  describe("findWordConnections", () => {
+    // TODO: fix any
+    let result: any;
+
+    it("returns empty if any string is empty", () => {
+      result = findWordConnections("", "");
+      expect(result).toStrictEqual([]);
+
+      result = findWordConnections("a", "");
+      expect(result).toStrictEqual([]);
+
+      result = findWordConnections("", "a");
+      expect(result).toStrictEqual([]);
+    });
+
+    it("returns Same if same word is provided", () => {
+      result = findWordConnections("a", "a");
+      expect(result).toStrictEqual([{ type: WordConnection.Same }]);
+
+      result = findWordConnections("word", "word");
+      expect(result).toStrictEqual([{ type: WordConnection.Same }]);
+    });
+
+    it("returns Anagram is words are anagrams", () => {
+      result = findWordConnections("dog", "god");
+      expect(result).toStrictEqual([{ type: WordConnection.Anagram }]);
+    });
+
+    it("returns empty if no word connection", () => {
+      result = findWordConnections("word", "sentence");
+      expect(result).toStrictEqual([]);
     });
   });
 

--- a/src/helpers/__tests__/strings.test.ts
+++ b/src/helpers/__tests__/strings.test.ts
@@ -3,6 +3,7 @@ import {
   areAnagrams,
   decomposeWord,
   findAdditionWordConnections,
+  findReplacementWordConnections,
   findWordConnections,
   pluralize
 } from "../strings";
@@ -13,6 +14,7 @@ describe("strings helper", () => {
     expect(typeof areAnagrams).toBe("function");
     expect(typeof decomposeWord).toBe("function");
     expect(typeof findAdditionWordConnections).toBe("function");
+    expect(typeof findReplacementWordConnections).toBe("function");
     expect(typeof findWordConnections).toBe("function");
     expect(typeof pluralize).toBe("function");
   });
@@ -141,6 +143,49 @@ describe("strings helper", () => {
 
     it("returns empty if no word connection", () => {
       result = findAdditionWordConnections("word", "sentence");
+      expect(result).toStrictEqual([]);
+    });
+  });
+
+  describe("findReplacementWordConnections", () => {
+    // TODO: fix any
+    let result: any;
+
+    it("returns empty if any string is empty", () => {
+      result = findReplacementWordConnections("", "");
+      expect(result).toStrictEqual([]);
+
+      result = findReplacementWordConnections("a", "");
+      expect(result).toStrictEqual([]);
+
+      result = findReplacementWordConnections("", "a");
+      expect(result).toStrictEqual([]);
+    });
+
+    it("returns empty if same word is provided", () => {
+      result = findReplacementWordConnections("a", "a");
+      expect(result).toStrictEqual([]);
+    });
+
+    it("returns connections when applicable", () => {
+      result = findReplacementWordConnections("bar", "car");
+      expect(result).toStrictEqual([
+        { character: "c", position: 0, type: WordConnection.Replacement }
+      ]);
+
+      result = findReplacementWordConnections("dig", "dog");
+      expect(result).toStrictEqual([
+        { character: "o", position: 1, type: WordConnection.Replacement }
+      ]);
+
+      result = findReplacementWordConnections("car", "cat");
+      expect(result).toStrictEqual([
+        { character: "t", position: 2, type: WordConnection.Replacement }
+      ]);
+    });
+
+    it("returns empty if no word connection", () => {
+      result = findReplacementWordConnections("word", "sentence");
       expect(result).toStrictEqual([]);
     });
   });

--- a/src/helpers/__tests__/strings.test.ts
+++ b/src/helpers/__tests__/strings.test.ts
@@ -3,6 +3,7 @@ import {
   areAnagrams,
   decomposeWord,
   findAdditionWordConnections,
+  findDeletionWordConnections,
   findReplacementWordConnections,
   findWordConnections,
   pluralize
@@ -14,6 +15,7 @@ describe("strings helper", () => {
     expect(typeof areAnagrams).toBe("function");
     expect(typeof decomposeWord).toBe("function");
     expect(typeof findAdditionWordConnections).toBe("function");
+    expect(typeof findDeletionWordConnections).toBe("function");
     expect(typeof findReplacementWordConnections).toBe("function");
     expect(typeof findWordConnections).toBe("function");
     expect(typeof pluralize).toBe("function");
@@ -143,6 +145,61 @@ describe("strings helper", () => {
 
     it("returns empty if no word connection", () => {
       result = findAdditionWordConnections("word", "sentence");
+      expect(result).toStrictEqual([]);
+    });
+  });
+
+  describe("findDeletionWordConnections", () => {
+    // TODO: fix any
+    let result: any;
+
+    it("returns empty if any string is empty", () => {
+      result = findDeletionWordConnections("", "");
+      expect(result).toStrictEqual([]);
+
+      result = findDeletionWordConnections("a", "");
+      expect(result).toStrictEqual([]);
+
+      result = findDeletionWordConnections("", "a");
+      expect(result).toStrictEqual([]);
+    });
+
+    it("returns empty if same word is provided", () => {
+      result = findDeletionWordConnections("a", "a");
+      expect(result).toStrictEqual([]);
+    });
+
+    it("returns connections when applicable", () => {
+      result = findDeletionWordConnections("hearth", "earth");
+      expect(result).toStrictEqual([
+        { position: 0, type: WordConnection.Deletion }
+      ]);
+
+      result = findDeletionWordConnections("hearth", "heart");
+      expect(result).toStrictEqual([
+        { position: 5, type: WordConnection.Deletion }
+      ]);
+
+      result = findDeletionWordConnections("then", "ten");
+      expect(result).toStrictEqual([
+        { position: 1, type: WordConnection.Deletion }
+      ]);
+
+      result = findDeletionWordConnections("good", "god");
+      expect(result).toStrictEqual([
+        {
+          position: 1,
+          type: WordConnection.Deletion
+        },
+        {
+          position: 2,
+          type: WordConnection.Deletion
+        }
+      ]);
+    });
+
+    it("returns empty if no word connection", () => {
+      result = findDeletionWordConnections("sentence", "word");
       expect(result).toStrictEqual([]);
     });
   });

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -1,10 +1,26 @@
 // Vendor
 import isEqual from "lodash/isEqual";
 
+// Internal
+import { WordConnection } from "../types/enum";
+
 const findWordConnections = (word1: string, word2: string) => {
-  if (word1 === word2) return [];
-  // TODO:
-  // return [];
+  if (!word1 || !word2) return [];
+
+  if (word1 === word2) {
+    return [{ type: WordConnection.Same }];
+  }
+
+  // TODO: type it
+  const wordConnections: any[] = [];
+
+  if (areAnagrams(word1, word2)) {
+    wordConnections.push({
+      type: WordConnection.Anagram
+    });
+  }
+
+  return wordConnections;
 };
 
 const areAnagrams = (word1: string, word2: string) => {
@@ -38,4 +54,4 @@ const decomposeWord = (word: string) => {
 const pluralize = (word: string, count: number) =>
   count === 1 ? `${count} ${word}` : `${count} ${word}s`;
 
-export { areAnagrams, decomposeWord, pluralize };
+export { areAnagrams, decomposeWord, findWordConnections, pluralize };

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -53,7 +53,11 @@ const decomposeWord = (word: string) => {
   return occurrences;
 };
 
-const findAdditionWordConnections = (word1: string, word2: string) => {
+const findAdditionWordConnections = (
+  word1: string,
+  word2: string,
+  type = WordConnection.Addition
+) => {
   if (!word1 || !word2) return [];
   if (word1 === word2) return [];
 
@@ -70,15 +74,21 @@ const findAdditionWordConnections = (word1: string, word2: string) => {
     const newWord2 = `${beginning}${end}`;
 
     if (word1 === newWord2) {
+      const characterObject =
+        type === WordConnection.Addition ? { character: word2[i] } : {};
       wordConnections.push({
-        character: word2[i],
+        ...characterObject,
         position: i,
-        type: WordConnection.Addition
+        type
       });
     }
   }
 
   return wordConnections;
+};
+
+const findDeletionWordConnections = (word1: string, word2: string) => {
+  return findAdditionWordConnections(word2, word1, WordConnection.Deletion);
 };
 
 const findReplacementWordConnections = (word1: string, word2: string) => {
@@ -114,6 +124,7 @@ export {
   areAnagrams,
   decomposeWord,
   findAdditionWordConnections,
+  findDeletionWordConnections,
   findReplacementWordConnections,
   findWordConnections,
   pluralize

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -1,7 +1,22 @@
+// Vendor
+import isEqual from "lodash/isEqual";
+
 const findWordConnections = (word1: string, word2: string) => {
   if (word1 === word2) return [];
   // TODO:
   // return [];
+};
+
+const areAnagrams = (word1: string, word2: string) => {
+  if (!word1 || !word2) return false;
+  if (word1 === word2) return false;
+
+  const decomposition1 = decomposeWord(word1);
+  const decomposition2 = decomposeWord(word2);
+
+  const valid = isEqual(decomposition1, decomposition2);
+
+  return valid;
 };
 
 const decomposeWord = (word: string) => {
@@ -20,4 +35,4 @@ const decomposeWord = (word: string) => {
 const pluralize = (word: string, count: number) =>
   count === 1 ? `${count} ${word}` : `${count} ${word}s`;
 
-export { decomposeWord, pluralize };
+export { areAnagrams, decomposeWord, pluralize };

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -62,8 +62,7 @@ const findAdditionWordConnections = (
   if (word1 === word2) return [];
 
   // TODO: same
-  const absLengthDiff = Math.abs(word1.length - word2.length);
-  if (absLengthDiff !== 1) return [];
+  if (word1.length + 1 !== word2.length) return [];
 
   // TODO: type it
   const wordConnections: any[] = [];

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -84,8 +84,8 @@ const findAdditionWordConnections = (
     const newWord2 = `${beginning}${end}`;
 
     if (word1 === newWord2) {
-      const characterObject =
-        type === WordConnection.Addition ? { character: word2[i] } : {};
+      const isAddition = type === WordConnection.Addition;
+      const characterObject = isAddition ? { character: word2[i] } : {};
       wordConnections.push({
         ...characterObject,
         position: i,

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -24,6 +24,7 @@ const findWordConnections = (word1: string, word2: string) => {
 };
 
 const areAnagrams = (word1: string, word2: string) => {
+  // TODO: make a function for next 2?
   if (!word1 || !word2) return false;
   if (word1 === word2) return false;
 
@@ -39,6 +40,7 @@ const areAnagrams = (word1: string, word2: string) => {
 };
 
 const decomposeWord = (word: string) => {
+  // TODO: make a function?
   const letters = word.split("");
   // TODO: fix any
   const occurrences: any = {};
@@ -51,7 +53,41 @@ const decomposeWord = (word: string) => {
   return occurrences;
 };
 
+const findAdditionWordConnections = (word1: string, word2: string) => {
+  if (!word1 || !word2) return [];
+  if (word1 === word2) return [];
+
+  // TODO: same
+  const absLengthDiff = Math.abs(word1.length - word2.length);
+  if (absLengthDiff !== 1) return [];
+
+  // TODO: type it
+  const wordConnections: any[] = [];
+
+  for (let i = 0; i < word2.length; i++) {
+    const beginning = word2.slice(0, i);
+    const end = word2.slice(i + 1);
+    const newWord2 = `${beginning}${end}`;
+
+    if (word1 === newWord2) {
+      wordConnections.push({
+        character: word2[i],
+        position: i,
+        type: WordConnection.Addition
+      });
+    }
+  }
+
+  return wordConnections;
+};
+
 const pluralize = (word: string, count: number) =>
   count === 1 ? `${count} ${word}` : `${count} ${word}s`;
 
-export { areAnagrams, decomposeWord, findWordConnections, pluralize };
+export {
+  areAnagrams,
+  decomposeWord,
+  findAdditionWordConnections,
+  findWordConnections,
+  pluralize
+};

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -20,6 +20,7 @@ const findWordConnections = (word1: string, word2: string) => {
     });
   }
 
+  // TODO: I think we can improve it with short-circuits everywhere as they have no intersection
   const additionConnections = findAdditionWordConnections(word1, word2);
   const deletionConnections = findDeletionWordConnections(word1, word2);
   const replacementConnections = findReplacementWordConnections(word1, word2);

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -20,6 +20,16 @@ const findWordConnections = (word1: string, word2: string) => {
     });
   }
 
+  const additionConnections = findAdditionWordConnections(word1, word2);
+  const deletionConnections = findDeletionWordConnections(word1, word2);
+  const replacementConnections = findReplacementWordConnections(word1, word2);
+
+  wordConnections.push(
+    ...additionConnections,
+    ...deletionConnections,
+    ...replacementConnections
+  );
+
   return wordConnections;
 };
 

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -1,4 +1,23 @@
+const findWordConnections = (word1: string, word2: string) => {
+  if (word1 === word2) return [];
+  // TODO:
+  // return [];
+};
+
+const decomposeWord = (word: string) => {
+  const letters = word.split("");
+  // TODO: fix any
+  const occurrences: any = {};
+
+  letters.forEach(letter => {
+    if (occurrences[letter]) occurrences[letter]++;
+    else occurrences[letter] = 1;
+  });
+
+  return occurrences;
+};
+
 const pluralize = (word: string, count: number) =>
   count === 1 ? `${count} ${word}` : `${count} ${word}s`;
 
-export { pluralize };
+export { decomposeWord, pluralize };

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -81,6 +81,32 @@ const findAdditionWordConnections = (word1: string, word2: string) => {
   return wordConnections;
 };
 
+const findReplacementWordConnections = (word1: string, word2: string) => {
+  if (!word1 || !word2) return [];
+  if (word1 === word2) return [];
+  if (word1.length !== word2.length) return [];
+
+  // TODO: type it
+  const wordConnections: any[] = [];
+
+  for (let i = 0; i < word2.length; i++) {
+    const beginning = word2.slice(0, i);
+    const middle = word1[i];
+    const end = word2.slice(i + 1);
+    const newWord2 = `${beginning}${middle}${end}`;
+
+    if (word1 === newWord2) {
+      wordConnections.push({
+        character: word2[i],
+        position: i,
+        type: WordConnection.Replacement
+      });
+    }
+  }
+
+  return wordConnections;
+};
+
 const pluralize = (word: string, count: number) =>
   count === 1 ? `${count} ${word}` : `${count} ${word}s`;
 
@@ -88,6 +114,7 @@ export {
   areAnagrams,
   decomposeWord,
   findAdditionWordConnections,
+  findReplacementWordConnections,
   findWordConnections,
   pluralize
 };

--- a/src/helpers/strings.ts
+++ b/src/helpers/strings.ts
@@ -11,6 +11,9 @@ const areAnagrams = (word1: string, word2: string) => {
   if (!word1 || !word2) return false;
   if (word1 === word2) return false;
 
+  // TODO: verify if it's faster thanks to this
+  if (word1.length !== word2.length) return false;
+
   const decomposition1 = decomposeWord(word1);
   const decomposition2 = decomposeWord(word2);
 

--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -7,6 +7,7 @@ enum Screen {
 enum WordConnection {
   Addition,
   Anagram,
+  Replacement,
   Same
 }
 

--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -7,6 +7,7 @@ enum Screen {
 enum WordConnection {
   Addition,
   Anagram,
+  Deletion,
   Replacement,
   Same
 }

--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -5,6 +5,7 @@ enum Screen {
 }
 
 enum WordConnection {
+  Addition,
   Anagram,
   Same
 }

--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -4,4 +4,9 @@ enum Screen {
   Game
 }
 
-export { Screen };
+enum WordConnection {
+  Anagram,
+  Same
+}
+
+export { Screen, WordConnection };


### PR DESCRIPTION
# Overview

**Previously,** codebase didn't have any word helper for finding connections between two words.
**Now,** we can detect anagrams, addition, deletion, replacement connections between two words.

# Testing

- [x] `npm run test` should be ✅

# Additional information

This isn't being used yet. Lots of TODO have been introduced as well.
