### PR TITLE
👓  Spectator mode draft

### DIFF
--- a/App/__tests__/__snapshots__/index.test.tsx.snap
+++ b/App/__tests__/__snapshots__/index.test.tsx.snap
@@ -351,7 +351,7 @@ Array [
           Words: 2
         </Text>
         <Text>
-          Words[0]: {"englishWord":"car","frenchWord":"voiture"}
+          Initial word: 0: {"englishWord":"car","frenchWord":"voiture"}
         </Text>
         <Text>
           Replacement words: cat

--- a/App/__tests__/__snapshots__/index.test.tsx.snap
+++ b/App/__tests__/__snapshots__/index.test.tsx.snap
@@ -351,10 +351,13 @@ Array [
           Words: 2
         </Text>
         <Text>
-          Initial word: 0: {"englishWord":"car","frenchWord":"voiture"}
+          History: car
         </Text>
         <Text>
           Replacement words: cat
+        </Text>
+        <Text>
+          Score: 0
         </Text>
       </View>
     </View>

--- a/App/__tests__/__snapshots__/index.test.tsx.snap
+++ b/App/__tests__/__snapshots__/index.test.tsx.snap
@@ -72,16 +72,15 @@ Array [
               }
             }
           />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
+        </View>
+        <View
+          style={
+            Object {
+              "flex": 1,
+              "flexDirection": "row",
             }
-          />
+          }
+        >
           <View
             style={
               Object {
@@ -131,36 +130,6 @@ Array [
               }
             }
           />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
         </View>
         <View
           style={
@@ -190,36 +159,6 @@ Array [
               }
             }
           />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
         </View>
         <View
           style={
@@ -229,95 +168,6 @@ Array [
             }
           }
         >
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-        </View>
-        <View
-          style={
-            Object {
-              "flex": 1,
-              "flexDirection": "row",
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
           <View
             style={
               Object {
@@ -373,7 +223,7 @@ Array [
                   }
                 }
               >
-                s
+                A
               </Text>
             </View>
           </View>
@@ -403,97 +253,7 @@ Array [
                   }
                 }
               >
-                t
-              </Text>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "alignItems": "center",
-                  "flex": 1,
-                  "justifyContent": "center",
-                }
-              }
-            >
-              <Text
-                style={
-                  Object {
-                    "fontSize": 30,
-                  }
-                }
-              >
-                o
-              </Text>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "alignItems": "center",
-                  "flex": 1,
-                  "justifyContent": "center",
-                }
-              }
-            >
-              <Text
-                style={
-                  Object {
-                    "fontSize": 30,
-                  }
-                }
-              >
-                v
-              </Text>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "alignItems": "center",
-                  "flex": 1,
-                  "justifyContent": "center",
-                }
-              }
-            >
-              <Text
-                style={
-                  Object {
-                    "fontSize": 30,
-                  }
-                }
-              >
-                e
+                F
               </Text>
             </View>
           </View>
@@ -511,7 +271,7 @@ Array [
           Words: 1645
         </Text>
         <Text>
-          Words[1299]: {"englishWord":"stove","frenchWord":""}
+          Words[0]: {"englishWord":"AF","frenchWord":""}
         </Text>
       </View>
     </View>

--- a/App/__tests__/__snapshots__/index.test.tsx.snap
+++ b/App/__tests__/__snapshots__/index.test.tsx.snap
@@ -102,16 +102,6 @@ Array [
               }
             }
           />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
         </View>
         <View
           style={
@@ -121,85 +111,6 @@ Array [
             }
           }
         >
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-        </View>
-        <View
-          style={
-            Object {
-              "flex": 1,
-              "flexDirection": "row",
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
           <View
             style={
               Object {
@@ -309,16 +220,6 @@ Array [
               }
             }
           />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
         </View>
         <View
           style={
@@ -338,6 +239,55 @@ Array [
               }
             }
           />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+        </View>
+        <View
+          style={
+            Object {
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
           <View
             style={
               Object {
@@ -453,7 +403,7 @@ Array [
                   }
                 }
               >
-                p
+                t
               </Text>
             </View>
           </View>
@@ -483,7 +433,7 @@ Array [
                   }
                 }
               >
-                l
+                o
               </Text>
             </View>
           </View>
@@ -513,7 +463,7 @@ Array [
                   }
                 }
               >
-                a
+                v
               </Text>
             </View>
           </View>
@@ -543,37 +493,7 @@ Array [
                   }
                 }
               >
-                s
-              </Text>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "alignItems": "center",
-                  "flex": 1,
-                  "justifyContent": "center",
-                }
-              }
-            >
-              <Text
-                style={
-                  Object {
-                    "fontSize": 30,
-                  }
-                }
-              >
-                h
+                e
               </Text>
             </View>
           </View>
@@ -588,7 +508,10 @@ Array [
         }
       >
         <Text>
-          Example
+          Words: 1645
+        </Text>
+        <Text>
+          Words[1299]: {"englishWord":"stove","frenchWord":""}
         </Text>
       </View>
     </View>

--- a/App/__tests__/__snapshots__/index.test.tsx.snap
+++ b/App/__tests__/__snapshots__/index.test.tsx.snap
@@ -27,339 +27,604 @@ Array [
         }
       }
     >
-      <Text
-        style={
+      <ScrollView
+        automaticallyAdjustContentInsets={false}
+        contentContainerStyle={
+          Array [
+            Object {
+              "padding": undefined,
+            },
+            undefined,
+          ]
+        }
+        contentInset={
           Object {
-            "textAlign": "center",
+            "bottom": 0,
           }
         }
-      >
-        Game
-      </Text>
-      <View
-        style={
+        enableAutomaticScroll={true}
+        enableOnAndroid={false}
+        enableResetScrollToCoords={true}
+        extraHeight={75}
+        extraScrollHeight={0}
+        keyboardDismissMode="interactive"
+        keyboardOpeningTime={250}
+        keyboardShouldPersistTaps="handled"
+        keyboardSpace={0}
+        resetScrollToCoords={
           Object {
-            "flex": 3,
-            "flexDirection": "column",
+            "x": 0,
+            "y": 0,
           }
         }
-      >
-        <View
-          style={
-            Object {
-              "flex": 1,
-              "flexDirection": "row",
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-        </View>
-        <View
-          style={
-            Object {
-              "flex": 1,
-              "flexDirection": "row",
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-        </View>
-        <View
-          style={
-            Object {
-              "flex": 1,
-              "flexDirection": "row",
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-        </View>
-        <View
-          style={
-            Object {
-              "flex": 1,
-              "flexDirection": "row",
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-        </View>
-        <View
-          style={
-            Object {
-              "flex": 1,
-              "flexDirection": "row",
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
-        </View>
-        <View
-          style={
-            Object {
-              "flex": 1,
-              "flexDirection": "row",
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "alignItems": "center",
-                  "flex": 1,
-                  "justifyContent": "center",
-                }
-              }
-            >
-              <Text
-                style={
-                  Object {
-                    "fontSize": 30,
-                  }
-                }
-              >
-                c
-              </Text>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "alignItems": "center",
-                  "flex": 1,
-                  "justifyContent": "center",
-                }
-              }
-            >
-              <Text
-                style={
-                  Object {
-                    "fontSize": 30,
-                  }
-                }
-              >
-                a
-              </Text>
-            </View>
-          </View>
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          >
-            <View
-              style={
-                Object {
-                  "alignItems": "center",
-                  "flex": 1,
-                  "justifyContent": "center",
-                }
-              }
-            >
-              <Text
-                style={
-                  Object {
-                    "fontSize": 30,
-                  }
-                }
-              >
-                r
-              </Text>
-            </View>
-          </View>
-        </View>
-      </View>
-      <View
+        scrollEventThrottle={1}
+        showsVerticalScrollIndicator={true}
         style={
           Object {
-            "backgroundColor": "yellow",
+            "backgroundColor": "transparent",
             "flex": 1,
           }
         }
+        viewIsInsideTabBar={false}
       >
-        <Text>
-          Words: 2
-        </Text>
-        <Text>
-          History: car
-        </Text>
-        <Text>
-          Replacement words: cat
-        </Text>
-        <Text>
-          Score: 0
-        </Text>
-      </View>
+        <View
+          style={Object {}}
+        >
+          <View
+            bordered={true}
+            style={
+              Object {
+                "backgroundColor": "#F0EFF5",
+                "borderBottomWidth": 0.5,
+                "borderColor": "#c9c9c9",
+                "borderTopWidth": 0.5,
+                "flex": 1,
+                "height": 35,
+                "justifyContent": "center",
+                "paddingBottom": 10,
+                "paddingLeft": 15,
+                "paddingTop": 12,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#777",
+                  "fontFamily": "System",
+                  "fontSize": 12,
+                }
+              }
+              uppercase={false}
+            >
+              Application
+            </Text>
+          </View>
+          <TouchableHighlight
+            activeOpacity={0.85}
+            delayPressOut={100}
+            underlayColor="#DDD"
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "borderBottomWidth": 0.5,
+                  "borderColor": "#c9c9c9",
+                  "flexDirection": "row",
+                  "marginLeft": 16,
+                  "paddingBottom": 13,
+                  "paddingRight": 16,
+                  "paddingTop": 13,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "color": "#000",
+                    "fontFamily": "System",
+                    "fontSize": 16,
+                  }
+                }
+                uppercase={false}
+              >
+                Created in 2018 - 2020
+              </Text>
+            </View>
+          </TouchableHighlight>
+          <TouchableHighlight
+            activeOpacity={0.85}
+            delayPressOut={100}
+            underlayColor="#DDD"
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "borderBottomWidth": 0.5,
+                  "borderColor": "#c9c9c9",
+                  "flexDirection": "row",
+                  "marginLeft": 16,
+                  "paddingBottom": 13,
+                  "paddingRight": 16,
+                  "paddingTop": 13,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "color": "#000",
+                    "fontFamily": "System",
+                    "fontSize": 16,
+                  }
+                }
+                uppercase={false}
+              >
+                Version unknown
+              </Text>
+            </View>
+          </TouchableHighlight>
+          <TouchableHighlight
+            activeOpacity={0.85}
+            delayPressOut={100}
+            underlayColor="#DDD"
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "borderBottomWidth": 0.5,
+                  "borderColor": "#c9c9c9",
+                  "flexDirection": "row",
+                  "marginLeft": 16,
+                  "paddingBottom": 13,
+                  "paddingRight": 16,
+                  "paddingTop": 13,
+                }
+              }
+            >
+              <View
+                style={
+                  Array [
+                    Object {
+                      "alignItems": "flex-start",
+                      "alignSelf": "center",
+                      "flex": 1,
+                      "flexDirection": "row",
+                    },
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  allowFontScaling={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": undefined,
+                        "fontSize": 12,
+                      },
+                      Array [
+                        Object {
+                          "color": "#000",
+                          "fontSize": 30,
+                        },
+                        Object {
+                          "color": "#000",
+                          "fontSize": 20,
+                          "width": 20,
+                        },
+                      ],
+                      Object {
+                        "fontFamily": "Ionicons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  
+                </Text>
+              </View>
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "alignSelf": "center",
+                      "color": "#000",
+                      "fontFamily": "System",
+                      "fontSize": 16,
+                    },
+                    Object {
+                      "flex": 4,
+                    },
+                  ]
+                }
+                uppercase={false}
+              >
+                Project's GitHub
+              </Text>
+            </View>
+          </TouchableHighlight>
+          <View
+            bordered={true}
+            style={
+              Object {
+                "backgroundColor": "#F0EFF5",
+                "borderBottomWidth": 0.5,
+                "borderColor": "#c9c9c9",
+                "borderTopWidth": 0.5,
+                "flex": 1,
+                "height": 35,
+                "justifyContent": "center",
+                "paddingBottom": 10,
+                "paddingLeft": 15,
+                "paddingTop": 12,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#777",
+                  "fontFamily": "System",
+                  "fontSize": 12,
+                }
+              }
+              uppercase={false}
+            >
+              Author
+            </Text>
+          </View>
+          <TouchableHighlight
+            activeOpacity={0.85}
+            delayPressOut={100}
+            underlayColor="#DDD"
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "borderBottomWidth": 0.5,
+                  "borderColor": "#c9c9c9",
+                  "flexDirection": "row",
+                  "marginLeft": 16,
+                  "paddingBottom": 13,
+                  "paddingRight": 16,
+                  "paddingTop": 13,
+                }
+              }
+            >
+              <View
+                style={
+                  Array [
+                    Object {
+                      "alignItems": "flex-start",
+                      "alignSelf": "center",
+                      "flex": 1,
+                      "flexDirection": "row",
+                    },
+                    Object {
+                      "flex": 1,
+                    },
+                  ]
+                }
+              >
+                <Image
+                  source={
+                    Object {
+                      "uri": "https://avatars1.githubusercontent.com/u/25478895",
+                    }
+                  }
+                  style={
+                    Object {
+                      "borderRadius": 28,
+                      "height": 56,
+                      "width": 56,
+                    }
+                  }
+                />
+              </View>
+              <View
+                style={
+                  Array [
+                    Object {
+                      "alignItems": null,
+                      "alignSelf": null,
+                      "flex": 1,
+                    },
+                    Object {
+                      "flex": 4,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "#000",
+                      "fontFamily": "System",
+                      "fontSize": 16,
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                    }
+                  }
+                  uppercase={false}
+                >
+                  sebranly
+                </Text>
+                <Text
+                  note={true}
+                  style={
+                    Object {
+                      "color": "#808080",
+                      "fontFamily": "System",
+                      "fontSize": 14,
+                      "fontWeight": "200",
+                      "marginLeft": 10,
+                      "marginRight": 10,
+                    }
+                  }
+                  uppercase={false}
+                >
+                  Developer/Tester
+                </Text>
+              </View>
+            </View>
+          </TouchableHighlight>
+          <View
+            bordered={true}
+            style={
+              Object {
+                "backgroundColor": "#F0EFF5",
+                "borderBottomWidth": 0.5,
+                "borderColor": "#c9c9c9",
+                "borderTopWidth": 0.5,
+                "flex": 1,
+                "height": 35,
+                "justifyContent": "center",
+                "paddingBottom": 10,
+                "paddingLeft": 15,
+                "paddingTop": 12,
+              }
+            }
+          >
+            <Text
+              style={
+                Object {
+                  "color": "#777",
+                  "fontFamily": "System",
+                  "fontSize": 12,
+                }
+              }
+              uppercase={false}
+            >
+              Libraries used
+            </Text>
+          </View>
+          <TouchableHighlight
+            activeOpacity={0.85}
+            delayPressOut={100}
+            underlayColor="#DDD"
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "borderBottomWidth": 0.5,
+                  "borderColor": "#c9c9c9",
+                  "flexDirection": "row",
+                  "marginLeft": 16,
+                  "paddingBottom": 13,
+                  "paddingRight": 16,
+                  "paddingTop": 13,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "color": "#000",
+                    "fontFamily": "System",
+                    "fontSize": 16,
+                  }
+                }
+                uppercase={false}
+              >
+                @testing-library/react-native
+              </Text>
+            </View>
+          </TouchableHighlight>
+          <TouchableHighlight
+            activeOpacity={0.85}
+            delayPressOut={100}
+            underlayColor="#DDD"
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "borderBottomWidth": 0.5,
+                  "borderColor": "#c9c9c9",
+                  "flexDirection": "row",
+                  "marginLeft": 16,
+                  "paddingBottom": 13,
+                  "paddingRight": 16,
+                  "paddingTop": 13,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "color": "#000",
+                    "fontFamily": "System",
+                    "fontSize": 16,
+                  }
+                }
+                uppercase={false}
+              >
+                emoji-from-text
+              </Text>
+            </View>
+          </TouchableHighlight>
+          <TouchableHighlight
+            activeOpacity={0.85}
+            delayPressOut={100}
+            underlayColor="#DDD"
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "borderBottomWidth": 0.5,
+                  "borderColor": "#c9c9c9",
+                  "flexDirection": "row",
+                  "marginLeft": 16,
+                  "paddingBottom": 13,
+                  "paddingRight": 16,
+                  "paddingTop": 13,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "color": "#000",
+                    "fontFamily": "System",
+                    "fontSize": 16,
+                  }
+                }
+                uppercase={false}
+              >
+                native-base
+              </Text>
+            </View>
+          </TouchableHighlight>
+          <TouchableHighlight
+            activeOpacity={0.85}
+            delayPressOut={100}
+            underlayColor="#DDD"
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "borderBottomWidth": 0.5,
+                  "borderColor": "#c9c9c9",
+                  "flexDirection": "row",
+                  "marginLeft": 16,
+                  "paddingBottom": 13,
+                  "paddingRight": 16,
+                  "paddingTop": 13,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "color": "#000",
+                    "fontFamily": "System",
+                    "fontSize": 16,
+                  }
+                }
+                uppercase={false}
+              >
+                node-emoji
+              </Text>
+            </View>
+          </TouchableHighlight>
+          <TouchableHighlight
+            activeOpacity={0.85}
+            delayPressOut={100}
+            underlayColor="#DDD"
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "borderBottomWidth": 0.5,
+                  "borderColor": "#c9c9c9",
+                  "flexDirection": "row",
+                  "marginLeft": 16,
+                  "paddingBottom": 13,
+                  "paddingRight": 16,
+                  "paddingTop": 13,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "color": "#000",
+                    "fontFamily": "System",
+                    "fontSize": 16,
+                  }
+                }
+                uppercase={false}
+              >
+                react-native
+              </Text>
+            </View>
+          </TouchableHighlight>
+          <TouchableHighlight
+            activeOpacity={0.85}
+            delayPressOut={100}
+            underlayColor="#DDD"
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "borderBottomWidth": 0.5,
+                  "borderColor": "#c9c9c9",
+                  "flexDirection": "row",
+                  "marginLeft": 16,
+                  "paddingBottom": 13,
+                  "paddingRight": 16,
+                  "paddingTop": 13,
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "alignSelf": "center",
+                    "color": "#000",
+                    "fontFamily": "System",
+                    "fontSize": 16,
+                  }
+                }
+                uppercase={false}
+              >
+                react-native-easy-grid
+              </Text>
+            </View>
+          </TouchableHighlight>
+        </View>
+      </ScrollView>
     </View>
     <View
       style={
@@ -470,87 +735,6 @@ Array [
           </Text>
         </TouchableOpacity>
         <TouchableOpacity
-          active={true}
-          activeOpacity={0.5}
-          style={
-            Object {
-              "alignItems": "center",
-              "alignSelf": "center",
-              "backgroundColor": "#cde1f9",
-              "borderBottomWidth": null,
-              "borderColor": null,
-              "borderLeftWidth": null,
-              "borderRadius": 5,
-              "borderRightWidth": null,
-              "borderTopWidth": null,
-              "borderWidth": undefined,
-              "elevation": 0,
-              "flex": 1,
-              "flexDirection": "column",
-              "height": null,
-              "justifyContent": "center",
-              "paddingBottom": 6,
-              "paddingTop": 6,
-              "shadowColor": null,
-              "shadowOffset": null,
-              "shadowOpacity": null,
-              "shadowRadius": null,
-            }
-          }
-          vertical={true}
-        >
-          <Text
-            allowFontScaling={false}
-            style={
-              Array [
-                Object {
-                  "color": undefined,
-                  "fontSize": 12,
-                },
-                Array [
-                  Object {
-                    "color": "#000",
-                    "fontSize": 30,
-                  },
-                  Object {
-                    "color": "#007aff",
-                    "fontSize": 24,
-                    "marginLeft": 16,
-                    "marginRight": 16,
-                    "paddingTop": 2,
-                  },
-                ],
-                Object {
-                  "fontFamily": "Ionicons",
-                  "fontStyle": "normal",
-                  "fontWeight": "normal",
-                },
-                Object {},
-              ]
-            }
-          >
-            
-          </Text>
-          <Text
-            style={
-              Object {
-                "backgroundColor": "transparent",
-                "color": "#007aff",
-                "fontFamily": "System",
-                "fontSize": 14,
-                "lineHeight": 16,
-                "marginLeft": 0,
-                "marginRight": 0,
-                "paddingLeft": 16,
-                "paddingRight": 16,
-              }
-            }
-            uppercase={false}
-          >
-            Play
-          </Text>
-        </TouchableOpacity>
-        <TouchableOpacity
           active={false}
           activeOpacity={0.5}
           style={
@@ -610,13 +794,94 @@ Array [
               ]
             }
           >
-            
+            
           </Text>
           <Text
             style={
               Object {
                 "backgroundColor": "transparent",
                 "color": "#6b6b6b",
+                "fontFamily": "System",
+                "fontSize": 14,
+                "lineHeight": 16,
+                "marginLeft": 0,
+                "marginRight": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+              }
+            }
+            uppercase={false}
+          >
+            Play
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          active={true}
+          activeOpacity={0.5}
+          style={
+            Object {
+              "alignItems": "center",
+              "alignSelf": "center",
+              "backgroundColor": "#cde1f9",
+              "borderBottomWidth": null,
+              "borderColor": null,
+              "borderLeftWidth": null,
+              "borderRadius": 5,
+              "borderRightWidth": null,
+              "borderTopWidth": null,
+              "borderWidth": undefined,
+              "elevation": 0,
+              "flex": 1,
+              "flexDirection": "column",
+              "height": null,
+              "justifyContent": "center",
+              "paddingBottom": 6,
+              "paddingTop": 6,
+              "shadowColor": null,
+              "shadowOffset": null,
+              "shadowOpacity": null,
+              "shadowRadius": null,
+            }
+          }
+          vertical={true}
+        >
+          <Text
+            allowFontScaling={false}
+            style={
+              Array [
+                Object {
+                  "color": undefined,
+                  "fontSize": 12,
+                },
+                Array [
+                  Object {
+                    "color": "#000",
+                    "fontSize": 30,
+                  },
+                  Object {
+                    "color": "#007aff",
+                    "fontSize": 24,
+                    "marginLeft": 16,
+                    "marginRight": 16,
+                    "paddingTop": 2,
+                  },
+                ],
+                Object {
+                  "fontFamily": "Ionicons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                Object {},
+              ]
+            }
+          >
+            
+          </Text>
+          <Text
+            style={
+              Object {
+                "backgroundColor": "transparent",
+                "color": "#007aff",
                 "fontFamily": "System",
                 "fontSize": 14,
                 "lineHeight": 16,

--- a/App/__tests__/__snapshots__/index.test.tsx.snap
+++ b/App/__tests__/__snapshots__/index.test.tsx.snap
@@ -72,25 +72,6 @@ Array [
               }
             }
           />
-        </View>
-        <View
-          style={
-            Object {
-              "flex": 1,
-              "flexDirection": "row",
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "backgroundColor": "grey",
-                "flex": 1,
-                "flexDirection": "column",
-                "margin": 2,
-              }
-            }
-          />
           <View
             style={
               Object {
@@ -130,6 +111,16 @@ Array [
               }
             }
           />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
         </View>
         <View
           style={
@@ -159,6 +150,16 @@ Array [
               }
             }
           />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
         </View>
         <View
           style={
@@ -168,6 +169,55 @@ Array [
             }
           }
         >
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
+        </View>
+        <View
+          style={
+            Object {
+              "flex": 1,
+              "flexDirection": "row",
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          />
           <View
             style={
               Object {
@@ -223,7 +273,7 @@ Array [
                   }
                 }
               >
-                A
+                c
               </Text>
             </View>
           </View>
@@ -253,7 +303,37 @@ Array [
                   }
                 }
               >
-                F
+                a
+              </Text>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "grey",
+                "flex": 1,
+                "flexDirection": "column",
+                "margin": 2,
+              }
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "center",
+                  "flex": 1,
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <Text
+                style={
+                  Object {
+                    "fontSize": 30,
+                  }
+                }
+              >
+                r
               </Text>
             </View>
           </View>
@@ -268,10 +348,10 @@ Array [
         }
       >
         <Text>
-          Words: 1645
+          Words: 2
         </Text>
         <Text>
-          Words[0]: {"englishWord":"AF","frenchWord":""}
+          Words[0]: {"englishWord":"car","frenchWord":"voiture"}
         </Text>
       </View>
     </View>

--- a/App/__tests__/__snapshots__/index.test.tsx.snap
+++ b/App/__tests__/__snapshots__/index.test.tsx.snap
@@ -353,6 +353,9 @@ Array [
         <Text>
           Words[0]: {"englishWord":"car","frenchWord":"voiture"}
         </Text>
+        <Text>
+          Replacement words: cat
+        </Text>
       </View>
     </View>
     <View

--- a/App/index.tsx
+++ b/App/index.tsx
@@ -58,7 +58,9 @@ const App: React.FC<AppProps> = (props) => {
 
   // TODO: remove 5 limit
   const allWords = cloneDeep(ALL_WORDS.filter((w) => w.englishWord.length < 5));
-  const initialWordIndex = IS_TEST ? 0 : random(allWords.length - 1);
+  // const initialWordIndex = IS_TEST ? 0 : random(allWords.length - 1);
+  // TODO: remove hardcoded value
+  const initialWordIndex = 315;
 
   // Markup
   return (

--- a/App/index.tsx
+++ b/App/index.tsx
@@ -57,8 +57,11 @@ const App: React.FC<AppProps> = (props) => {
   const isGame = screen === Screen.Game;
 
   // TODO: remove 5 limit
-  const allWords = cloneDeep(ALL_WORDS.filter((w) => w.englishWord.length < 5));
-  const initialWordIndex = IS_TEST ? 0 : random(allWords.length - 1);
+  const filteredWords = cloneDeep(
+    ALL_WORDS.filter((w) => w.englishWord.length < 5)
+  );
+
+  const initialWordIndex = IS_TEST ? 0 : random(filteredWords.length - 1);
 
   // Markup
   return (
@@ -66,7 +69,7 @@ const App: React.FC<AppProps> = (props) => {
       {isAbout && <About />}
       {isExplore && <Results />}
       {isGame && (
-        <Game allWords={allWords} initialWordIndex={initialWordIndex} />
+        <Game allWords={filteredWords} initialWordIndex={initialWordIndex} />
       )}
       <Footer changeScreen={changeScreen} screen={screen} />
     </Container>

--- a/App/index.tsx
+++ b/App/index.tsx
@@ -1,6 +1,7 @@
 // Vendor
 import * as Font from "expo-font";
 import * as React from "react";
+import cloneDeep from "lodash/cloneDeep";
 import { AppLoading } from "expo";
 import { Container } from "native-base";
 import { Ionicons } from "@expo/vector-icons";
@@ -12,13 +13,13 @@ import { Footer } from "../src/components/Footer";
 import { Game } from "../src/components/Game";
 import { Results } from "../src/components/Results";
 import { Screen } from "../src/types/enum";
-import { HEADER_Y } from "../src/config/settings";
+import { ALL_WORDS, HEADER_Y } from "../src/config/settings";
 
 export interface AppProps {
   initialReady?: boolean;
 }
 
-const App: React.FC<AppProps> = props => {
+const App: React.FC<AppProps> = (props) => {
   // Setup
   const { initialReady } = props;
 
@@ -32,7 +33,7 @@ const App: React.FC<AppProps> = props => {
       await Font.loadAsync({
         Roboto: require("../node_modules/native-base/Fonts/Roboto.ttf"),
         Roboto_medium: require("../node_modules/native-base/Fonts/Roboto_medium.ttf"),
-        ...Ionicons.font
+        ...Ionicons.font,
       });
 
       setIsReady(true);
@@ -53,28 +54,29 @@ const App: React.FC<AppProps> = props => {
   const isAbout = screen === Screen.About;
   const isExplore = screen === Screen.Explore;
   const isGame = screen === Screen.Game;
+  const allWords = cloneDeep(ALL_WORDS);
 
   // Markup
   return (
     <Container style={styles.container}>
       {isAbout && <About />}
       {isExplore && <Results />}
-      {isGame && <Game word={"splash"} />}
+      {isGame && <Game words={allWords} />}
       <Footer changeScreen={changeScreen} screen={screen} />
     </Container>
   );
 };
 
 App.defaultProps = {
-  initialReady: false
+  initialReady: false,
 };
 
 const styles = StyleSheet.create({
   container: {
     backgroundColor: "#fff",
     flex: 1,
-    paddingTop: HEADER_Y
-  }
+    paddingTop: HEADER_Y,
+  },
 });
 
 export default App;

--- a/App/index.tsx
+++ b/App/index.tsx
@@ -26,7 +26,7 @@ const App: React.FC<AppProps> = (props) => {
 
   // Hooks
   const [isReady, setIsReady] = React.useState(initialReady);
-  const [screen, setScreen] = React.useState(Screen.Game);
+  const [screen, setScreen] = React.useState(Screen.About);
 
   // Life-cycle
   React.useEffect(() => {

--- a/App/index.tsx
+++ b/App/index.tsx
@@ -58,9 +58,7 @@ const App: React.FC<AppProps> = (props) => {
 
   // TODO: remove 5 limit
   const allWords = cloneDeep(ALL_WORDS.filter((w) => w.englishWord.length < 5));
-  // const initialWordIndex = IS_TEST ? 0 : random(allWords.length - 1);
-  // TODO: remove hardcoded value
-  const initialWordIndex = 315;
+  const initialWordIndex = IS_TEST ? 0 : random(allWords.length - 1);
 
   // Markup
   return (

--- a/App/index.tsx
+++ b/App/index.tsx
@@ -54,7 +54,9 @@ const App: React.FC<AppProps> = (props) => {
   const isAbout = screen === Screen.About;
   const isExplore = screen === Screen.Explore;
   const isGame = screen === Screen.Game;
-  const allWords = cloneDeep(ALL_WORDS);
+
+  // TODO: remove 5 limit
+  const allWords = cloneDeep(ALL_WORDS.filter((w) => w.englishWord.length < 5));
 
   // Markup
   return (

--- a/App/index.tsx
+++ b/App/index.tsx
@@ -2,6 +2,7 @@
 import * as Font from "expo-font";
 import * as React from "react";
 import cloneDeep from "lodash/cloneDeep";
+import random from "lodash/random";
 import { AppLoading } from "expo";
 import { Container } from "native-base";
 import { Ionicons } from "@expo/vector-icons";
@@ -13,7 +14,7 @@ import { Footer } from "../src/components/Footer";
 import { Game } from "../src/components/Game";
 import { Results } from "../src/components/Results";
 import { Screen } from "../src/types/enum";
-import { ALL_WORDS, HEADER_Y } from "../src/config/settings";
+import { ALL_WORDS, HEADER_Y, IS_TEST } from "../src/config/settings";
 
 export interface AppProps {
   initialReady?: boolean;
@@ -57,13 +58,16 @@ const App: React.FC<AppProps> = (props) => {
 
   // TODO: remove 5 limit
   const allWords = cloneDeep(ALL_WORDS.filter((w) => w.englishWord.length < 5));
+  const initialWordIndex = IS_TEST ? 0 : random(allWords.length - 1);
 
   // Markup
   return (
     <Container style={styles.container}>
       {isAbout && <About />}
       {isExplore && <Results />}
-      {isGame && <Game allWords={allWords} />}
+      {isGame && (
+        <Game allWords={allWords} initialWordIndex={initialWordIndex} />
+      )}
       <Footer changeScreen={changeScreen} screen={screen} />
     </Container>
   );

--- a/App/index.tsx
+++ b/App/index.tsx
@@ -63,7 +63,7 @@ const App: React.FC<AppProps> = (props) => {
     <Container style={styles.container}>
       {isAbout && <About />}
       {isExplore && <Results />}
-      {isGame && <Game words={allWords} />}
+      {isGame && <Game allWords={allWords} />}
       <Footer changeScreen={changeScreen} screen={screen} />
     </Container>
   );

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,6 @@
 
 # Testing
 
-- [ ] `npm run test` should be ✅
 - [ ] App should be available on a real device (iPhone) after running `npm run start`
 
 # Additional information

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -47,6 +47,7 @@ const Game: React.FC<GameProps> = (props) => {
 
   // Hooks
   const [end, setEnd] = React.useState(false);
+  const [score, setScore] = React.useState(0);
   const [words, setWords] = React.useState(initialWords);
   const [wordsConnections, setWordsConnections] = React.useState([] as Word[]);
 
@@ -71,6 +72,9 @@ const Game: React.FC<GameProps> = (props) => {
 
           const newConnections = findReplacements(newWords);
           setWordsConnections(newConnections);
+
+          const additionalScore = 10;
+          setScore((previousScore) => previousScore + additionalScore);
 
           if (newConnections.length === 0) setEnd(true);
 
@@ -139,6 +143,7 @@ const Game: React.FC<GameProps> = (props) => {
             .map((w) => w.englishWord)
             .join(" ")}`}</Text>
         )}
+        {<Text>{`Score: ${score}`}</Text>}
         {end && <Text>Game Over</Text>}
       </View>
     </Container>

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -19,12 +19,17 @@ export interface GameProps {
 
 const Game: React.FC<GameProps> = (props) => {
   // TODO: move out
-  const findReplacements = (currentWord: Word) => {
-    const replacements = allWords.filter((w) => {
-      const connections = findWordConnections(
-        currentWord.englishWord,
-        w.englishWord
-      );
+  // words is the history of all played words. Last one is current one.
+  const findReplacements = (words: Word[]) => {
+    const word = words[words.length - 1];
+
+    const bannedWords = words.map((w) => w.englishWord);
+    const filteredWords = allWords.filter((w) => {
+      return !bannedWords.includes(w.englishWord);
+    });
+
+    const replacements = filteredWords.filter((w) => {
+      const connections = findWordConnections(word.englishWord, w.englishWord);
 
       const replacementsConnections = connections.filter(
         (c) => c.type === WordConnection.Replacement
@@ -54,8 +59,7 @@ const Game: React.FC<GameProps> = (props) => {
      * TODO: can the setState hooks be cleaned up?
      */
     setWords((words) => {
-      const word = words[words.length - 1];
-      const connections = findReplacements(word);
+      const connections = findReplacements(words);
 
       if (initial) {
         setWordsConnections(connections);
@@ -63,10 +67,14 @@ const Game: React.FC<GameProps> = (props) => {
       } else {
         if (connections.length > 0) {
           const newWord = connections[0];
-          const newConnections = findReplacements(newWord);
+          const newWords = [...words, newWord];
+
+          const newConnections = findReplacements(newWords);
           setWordsConnections(newConnections);
 
-          return [...words, newWord];
+          if (newConnections.length === 0) setEnd(true);
+
+          return newWords;
         } else {
           setEnd(true);
         }

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -8,7 +8,7 @@ import { Text } from "react-native";
 
 // Internal
 import { Word } from "../types/interfaces";
-import { GAME_ROWS } from "../config/settings";
+import { GAME_ROWS, IS_TEST } from "../config/settings";
 
 export interface GameProps {
   style?: any;
@@ -18,7 +18,7 @@ export interface GameProps {
 const Game: React.FC<GameProps> = (props) => {
   // Setup
   const { words } = props;
-  const wordIndex = random(words.length - 1);
+  const wordIndex = IS_TEST ? 0 : random(words.length - 1);
   const initialWord = words[wordIndex];
 
   // Hooks

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -13,22 +13,22 @@ import { WordConnection } from "../types/enum";
 import { GAME_ROWS, IS_TEST } from "../config/settings";
 
 export interface GameProps {
+  allWords: Word[];
   style?: any;
-  words: Word[];
 }
 
 const Game: React.FC<GameProps> = (props) => {
   // Setup
-  const { words } = props;
-  const wordIndex = IS_TEST ? 0 : random(words.length - 1);
-  const initialWord = words[wordIndex];
+  const { allWords } = props;
+  const wordIndex = IS_TEST ? 0 : random(allWords.length - 1);
+  const initialWord = allWords[wordIndex];
 
   // Hooks
   const [word, _setWord] = React.useState(initialWord);
 
   // TODO: move out
   const findReplacements = (currentWord: Word) => {
-    const replacements = words.filter((w) => {
+    const replacements = allWords.filter((w) => {
       const connections = findWordConnections(
         currentWord.englishWord,
         w.englishWord
@@ -84,9 +84,9 @@ const Game: React.FC<GameProps> = (props) => {
       <Text style={styles.title}>Game</Text>
       <Grid style={styles.grid}>{renderRows()}</Grid>
       <View style={styles.example}>
-        <Text>{`Words: ${words.length}`}</Text>
+        <Text>{`Words: ${allWords.length}`}</Text>
         <Text>{`Words[${wordIndex}]: ${JSON.stringify(
-          words[wordIndex]
+          allWords[wordIndex]
         )}`}</Text>
         <Text>{`Replacement words: ${wordConnections
           .map((w) => w.englishWord)

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -1,20 +1,28 @@
 // Vendor
 import * as React from "react";
+import random from "lodash/random";
 import { Col, Grid, Row } from "react-native-easy-grid";
-import { Container, StyleProvider } from "native-base";
+import { Container } from "native-base";
 import { StyleSheet, View } from "react-native";
 import { Text } from "react-native";
 
 // Internal
+import { Word } from "../types/interfaces";
 import { GAME_ROWS } from "../config/settings";
 
 export interface GameProps {
   style?: any;
-  word: string;
+  words: Word[];
 }
 
-const Game: React.FC<GameProps> = props => {
-  const { word } = props;
+const Game: React.FC<GameProps> = (props) => {
+  // Setup
+  const { words } = props;
+  const wordIndex = random(words.length - 1);
+  const initialWord = words[wordIndex];
+
+  // Hooks
+  const [word, _setWord] = React.useState(initialWord);
 
   const renderRow = (indexRow: number, last?: boolean) => {
     const renderColumn = (letter: string, indexCol: number) => {
@@ -32,7 +40,7 @@ const Game: React.FC<GameProps> = props => {
     };
 
     const renderColumns = () => {
-      const letters = word.split("");
+      const letters = word.englishWord.split("");
       const columns = letters.map((v, i) => renderColumn(v, i));
       return columns;
     };
@@ -54,7 +62,10 @@ const Game: React.FC<GameProps> = props => {
       <Text style={styles.title}>Game</Text>
       <Grid style={styles.grid}>{renderRows()}</Grid>
       <View style={styles.example}>
-        <Text>Example</Text>
+        <Text>{`Words: ${words.length}`}</Text>
+        <Text>{`Words[${wordIndex}]: ${JSON.stringify(
+          words[wordIndex]
+        )}`}</Text>
       </View>
     </Container>
   );
@@ -63,24 +74,24 @@ const Game: React.FC<GameProps> = props => {
 const styles = StyleSheet.create({
   cell: {
     backgroundColor: "grey",
-    margin: 2
+    margin: 2,
   },
   example: {
     backgroundColor: "yellow",
-    flex: 1
+    flex: 1,
   },
   grid: {
-    flex: 3
+    flex: 3,
   },
   text: { fontSize: 30 },
   title: {
-    textAlign: "center"
+    textAlign: "center",
   },
   viewText: {
     alignItems: "center",
     flex: 1,
-    justifyContent: "center"
-  }
+    justifyContent: "center",
+  },
 });
 
 export { Game };

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -7,7 +7,9 @@ import { StyleSheet, View } from "react-native";
 import { Text } from "react-native";
 
 // Internal
+import { findWordConnections } from "../helpers/strings";
 import { Word } from "../types/interfaces";
+import { WordConnection } from "../types/enum";
 import { GAME_ROWS, IS_TEST } from "../config/settings";
 
 export interface GameProps {
@@ -23,6 +25,26 @@ const Game: React.FC<GameProps> = (props) => {
 
   // Hooks
   const [word, _setWord] = React.useState(initialWord);
+
+  // TODO: move out
+  const findReplacements = (currentWord: Word) => {
+    const replacements = words.filter((w) => {
+      const connections = findWordConnections(
+        currentWord.englishWord,
+        w.englishWord
+      );
+
+      const replacementsConnections = connections.filter(
+        (c) => c.type === WordConnection.Replacement
+      );
+
+      return replacementsConnections.length > 0;
+    });
+
+    return replacements;
+  };
+
+  const wordConnections = findReplacements(word);
 
   const renderRow = (indexRow: number, last?: boolean) => {
     const renderColumn = (letter: string, indexCol: number) => {
@@ -66,6 +88,9 @@ const Game: React.FC<GameProps> = (props) => {
         <Text>{`Words[${wordIndex}]: ${JSON.stringify(
           words[wordIndex]
         )}`}</Text>
+        <Text>{`Replacement words: ${wordConnections
+          .map((w) => w.englishWord)
+          .join(" ")}`}</Text>
       </View>
     </Container>
   );

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -21,10 +21,10 @@ const Game: React.FC<GameProps> = (props) => {
   // Setup
   const { allWords } = props;
   const wordIndex = IS_TEST ? 0 : random(allWords.length - 1);
-  const initialWord = allWords[wordIndex];
+  const initialWords = [allWords[wordIndex]];
 
   // Hooks
-  const [word, _setWord] = React.useState(initialWord);
+  const [words, _setWords] = React.useState(initialWords);
 
   // TODO: move out
   const findReplacements = (currentWord: Word) => {
@@ -44,7 +44,7 @@ const Game: React.FC<GameProps> = (props) => {
     return replacements;
   };
 
-  const wordConnections = findReplacements(word);
+  const wordConnections = findReplacements(words[words.length - 1]);
 
   const renderRow = (indexRow: number, last?: boolean) => {
     const renderColumn = (letter: string, indexCol: number) => {
@@ -62,7 +62,9 @@ const Game: React.FC<GameProps> = (props) => {
     };
 
     const renderColumns = () => {
+      const word = words[words.length - 1];
       const letters = word.englishWord.split("");
+
       const columns = letters.map((v, i) => renderColumn(v, i));
       return columns;
     };

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -7,9 +7,10 @@ import { Text } from "react-native";
 
 // Internal
 import { findWordConnections } from "../helpers/strings";
+import { getWordScore } from "../helpers/score";
 import { Word } from "../types/interfaces";
 import { WordConnection } from "../types/enum";
-import { GAME_ROWS } from "../config/settings";
+import { GAME_ROWS, SPECTATOR_INTERVAL } from "../config/settings";
 
 export interface GameProps {
   allWords: Word[];
@@ -73,7 +74,7 @@ const Game: React.FC<GameProps> = (props) => {
           const newConnections = findReplacements(newWords);
           setWordsConnections(newConnections);
 
-          const additionalScore = 10;
+          const additionalScore = getWordScore(newWord);
           setScore((previousScore) => previousScore + additionalScore);
 
           if (newConnections.length === 0) setEnd(true);
@@ -91,7 +92,7 @@ const Game: React.FC<GameProps> = (props) => {
   // Life-cycle
   React.useEffect(() => {
     onSpectator(true);
-    const intervalId = setInterval(onSpectator, 5000);
+    const intervalId = setInterval(onSpectator, SPECTATOR_INTERVAL);
 
     return () => clearInterval(intervalId);
   }, []); // Empty array leads to same behavior as `componentDidMount` (if it was a class)

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -1,6 +1,5 @@
 // Vendor
 import * as React from "react";
-import { Col, Grid, Row } from "react-native-easy-grid";
 import { Container } from "native-base";
 import { StyleSheet, View } from "react-native";
 import { Text } from "react-native";
@@ -8,9 +7,10 @@ import { Text } from "react-native";
 // Internal
 import { findWordConnections } from "../helpers/strings";
 import { getWordScore } from "../helpers/score";
+import { Grid } from "./Grid";
 import { Word } from "../types/interfaces";
 import { WordConnection } from "../types/enum";
-import { GAME_ROWS, SPECTATOR_INTERVAL } from "../config/settings";
+import { SPECTATOR_INTERVAL } from "../config/settings";
 
 export interface GameProps {
   allWords: Word[];
@@ -97,45 +97,10 @@ const Game: React.FC<GameProps> = (props) => {
     return () => clearInterval(intervalId);
   }, []); // Empty array leads to same behavior as `componentDidMount` (if it was a class)
 
-  const renderRow = (indexRow: number, last?: boolean) => {
-    const renderColumn = (letter: string, indexCol: number) => {
-      const innerComponent = last ? (
-        <View style={styles.viewText}>
-          <Text style={styles.text}>{letter}</Text>
-        </View>
-      ) : null;
-
-      return (
-        <Col key={`col-${indexCol}`} style={styles.cell}>
-          {innerComponent}
-        </Col>
-      );
-    };
-
-    const renderColumns = () => {
-      const word = words[words.length - 1];
-      const letters = word.englishWord.split("");
-
-      const columns = letters.map((v, i) => renderColumn(v, i));
-      return columns;
-    };
-
-    return <Row key={`row-${indexRow}`}>{renderColumns()}</Row>;
-  };
-
-  const renderRows = () => {
-    const lastIndexRow = GAME_ROWS - 1;
-    const allButLastRow = Array.from({ length: lastIndexRow }, (_v, i) =>
-      renderRow(i)
-    );
-
-    return [...allButLastRow, renderRow(lastIndexRow, true)];
-  };
-
   return (
     <Container>
       <Text style={styles.title}>Game</Text>
-      <Grid style={styles.grid}>{renderRows()}</Grid>
+      <Grid word={words[words.length - 1]} />
       <View style={styles.example}>
         <Text>{`Words: ${allWords.length}`}</Text>
         <Text>{`History: ${words.map((w) => w.englishWord)}`}</Text>
@@ -152,25 +117,12 @@ const Game: React.FC<GameProps> = (props) => {
 };
 
 const styles = StyleSheet.create({
-  cell: {
-    backgroundColor: "grey",
-    margin: 2,
-  },
   example: {
     backgroundColor: "yellow",
     flex: 1,
   },
-  grid: {
-    flex: 3,
-  },
-  text: { fontSize: 30 },
   title: {
     textAlign: "center",
-  },
-  viewText: {
-    alignItems: "center",
-    flex: 1,
-    justifyContent: "center",
   },
 });
 

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -64,10 +64,9 @@ const Game: React.FC<GameProps> = (props) => {
   // Life-cycle
   React.useEffect(() => {
     onSpectator(true);
-    // const timer = setTimeout(() => {
-    //   onSpectator();
-    // }, 5000);
-    // return () => clearTimeout(timer);
+
+    const intervalId = setInterval(onSpectator, 5000);
+    return () => clearInterval(intervalId);
   }, []); // Empty array leads to same behavior as `componentDidMount` (if it was a class)
 
   const renderRow = (indexRow: number, last?: boolean) => {
@@ -111,6 +110,7 @@ const Game: React.FC<GameProps> = (props) => {
       <Grid style={styles.grid}>{renderRows()}</Grid>
       <View style={styles.example}>
         <Text>{`Words: ${allWords.length}`}</Text>
+        <Text>{`History: ${words.map((w) => w.englishWord)}`}</Text>
         <Text>{debug}</Text>
         {!end && (
           <Text>{`Replacement words: ${wordsConnections

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -1,0 +1,71 @@
+// Vendor
+import * as React from "react";
+import { Col, Grid as EasyGrid, Row } from "react-native-easy-grid";
+import { StyleSheet, View } from "react-native";
+import { Text } from "react-native";
+
+// Internal
+import { Word } from "../types/interfaces";
+import { GAME_ROWS } from "../config/settings";
+
+export interface GridProps {
+  word: Word;
+}
+
+const Grid: React.FC<GridProps> = (props) => {
+  const { word } = props;
+
+  const renderRow = (indexRow: number, last?: boolean) => {
+    const renderColumn = (letter: string, indexCol: number) => {
+      const innerComponent = last ? (
+        <View style={styles.viewText}>
+          <Text style={styles.text}>{letter}</Text>
+        </View>
+      ) : null;
+
+      return (
+        <Col key={`col-${indexCol}`} style={styles.cell}>
+          {innerComponent}
+        </Col>
+      );
+    };
+
+    const renderColumns = () => {
+      const letters = word.englishWord.split("");
+
+      const columns = letters.map((v, i) => renderColumn(v, i));
+      return columns;
+    };
+
+    return <Row key={`row-${indexRow}`}>{renderColumns()}</Row>;
+  };
+
+  const renderRows = () => {
+    const lastIndexRow = GAME_ROWS - 1;
+    const allButLastRow = Array.from({ length: lastIndexRow }, (_v, i) =>
+      renderRow(i)
+    );
+
+    return [...allButLastRow, renderRow(lastIndexRow, true)];
+  };
+
+  return <EasyGrid style={styles.grid}>{renderRows()}</EasyGrid>;
+};
+
+const styles = StyleSheet.create({
+  cell: {
+    backgroundColor: "grey",
+    margin: 2,
+  },
+  grid: {
+    flex: 3,
+  },
+  text: { fontSize: 30 },
+  viewText: {
+    alignItems: "center",
+    flex: 1,
+    justifyContent: "center",
+  },
+});
+
+export { Grid };

--- a/src/components/__tests__/Game.test.tsx
+++ b/src/components/__tests__/Game.test.tsx
@@ -4,9 +4,16 @@ import { render } from "@testing-library/react-native";
 
 // Internal
 import { Game } from "../Game";
+import { Word } from "../../types/interfaces";
 
 it("renders", () => {
-  const props = { word: "test" };
+  const words: Word[] = [
+    { englishWord: "car", frenchWord: "voiture" },
+    { englishWord: "cat", frenchWord: "chat" },
+  ];
+
+  const props = { words };
+
   const { container } = render(<Game {...props} />);
   expect(container.children.length).toBeGreaterThan(0);
   expect(container.children).toMatchSnapshot();

--- a/src/components/__tests__/Game.test.tsx
+++ b/src/components/__tests__/Game.test.tsx
@@ -4,15 +4,11 @@ import { render } from "@testing-library/react-native";
 
 // Internal
 import { Game } from "../Game";
+import { mockWords } from "../../mocks";
 import { Word } from "../../types/interfaces";
 
 it("renders", () => {
-  const words: Word[] = [
-    { englishWord: "car", frenchWord: "voiture" },
-    { englishWord: "cat", frenchWord: "chat" },
-  ];
-
-  const props = { words };
+  const props = { words: mockWords };
 
   const { container } = render(<Game {...props} />);
   expect(container.children.length).toBeGreaterThan(0);

--- a/src/components/__tests__/Game.test.tsx
+++ b/src/components/__tests__/Game.test.tsx
@@ -8,7 +8,7 @@ import { mockWords } from "../../mocks";
 import { Word } from "../../types/interfaces";
 
 it("renders", () => {
-  const props = { allWords: mockWords };
+  const props = { allWords: mockWords, initialWordIndex: 0 };
 
   const { container } = render(<Game {...props} />);
   expect(container.children.length).toBeGreaterThan(0);

--- a/src/components/__tests__/Game.test.tsx
+++ b/src/components/__tests__/Game.test.tsx
@@ -8,7 +8,7 @@ import { mockWords } from "../../mocks";
 import { Word } from "../../types/interfaces";
 
 it("renders", () => {
-  const props = { words: mockWords };
+  const props = { allWords: mockWords };
 
   const { container } = render(<Game {...props} />);
   expect(container.children.length).toBeGreaterThan(0);

--- a/src/components/__tests__/Grid.test.tsx
+++ b/src/components/__tests__/Grid.test.tsx
@@ -3,13 +3,13 @@ import React from "react";
 import { render } from "@testing-library/react-native";
 
 // Internal
-import { Game } from "../Game";
+import { Grid } from "../Grid";
 import { mockWords } from "../../mocks";
 
 it("renders", () => {
-  const props = { allWords: mockWords, initialWordIndex: 0 };
+  const props = { word: mockWords[0] };
 
-  const { container } = render(<Game {...props} />);
+  const { container } = render(<Grid {...props} />);
   expect(container.children.length).toBeGreaterThan(0);
   expect(container.children).toMatchSnapshot();
 });

--- a/src/components/__tests__/__snapshots__/Game.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Game.test.tsx.snap
@@ -335,10 +335,13 @@ Array [
         Words: 2
       </Text>
       <Text>
-        Initial word: 0: {"englishWord":"car","frenchWord":"voiture"}
+        History: car
       </Text>
       <Text>
         Replacement words: cat
+      </Text>
+      <Text>
+        Score: 0
       </Text>
     </View>
   </View>,

--- a/src/components/__tests__/__snapshots__/Game.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Game.test.tsx.snap
@@ -337,6 +337,9 @@ Array [
       <Text>
         Words[0]: {"englishWord":"car","frenchWord":"voiture"}
       </Text>
+      <Text>
+        Replacement words: cat
+      </Text>
     </View>
   </View>,
 ]

--- a/src/components/__tests__/__snapshots__/Game.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Game.test.tsx.snap
@@ -335,7 +335,7 @@ Array [
         Words: 2
       </Text>
       <Text>
-        Words[0]: {"englishWord":"car","frenchWord":"voiture"}
+        Initial word: 0: {"englishWord":"car","frenchWord":"voiture"}
       </Text>
       <Text>
         Replacement words: cat

--- a/src/components/__tests__/__snapshots__/Game.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Game.test.tsx.snap
@@ -66,16 +66,6 @@ Array [
             }
           }
         />
-        <View
-          style={
-            Object {
-              "backgroundColor": "grey",
-              "flex": 1,
-              "flexDirection": "column",
-              "margin": 2,
-            }
-          }
-        />
       </View>
       <View
         style={
@@ -85,65 +75,6 @@ Array [
           }
         }
       >
-        <View
-          style={
-            Object {
-              "backgroundColor": "grey",
-              "flex": 1,
-              "flexDirection": "column",
-              "margin": 2,
-            }
-          }
-        />
-        <View
-          style={
-            Object {
-              "backgroundColor": "grey",
-              "flex": 1,
-              "flexDirection": "column",
-              "margin": 2,
-            }
-          }
-        />
-        <View
-          style={
-            Object {
-              "backgroundColor": "grey",
-              "flex": 1,
-              "flexDirection": "column",
-              "margin": 2,
-            }
-          }
-        />
-        <View
-          style={
-            Object {
-              "backgroundColor": "grey",
-              "flex": 1,
-              "flexDirection": "column",
-              "margin": 2,
-            }
-          }
-        />
-      </View>
-      <View
-        style={
-          Object {
-            "flex": 1,
-            "flexDirection": "row",
-          }
-        }
-      >
-        <View
-          style={
-            Object {
-              "backgroundColor": "grey",
-              "flex": 1,
-              "flexDirection": "column",
-              "margin": 2,
-            }
-          }
-        />
         <View
           style={
             Object {
@@ -213,16 +144,6 @@ Array [
             }
           }
         />
-        <View
-          style={
-            Object {
-              "backgroundColor": "grey",
-              "flex": 1,
-              "flexDirection": "column",
-              "margin": 2,
-            }
-          }
-        />
       </View>
       <View
         style={
@@ -242,6 +163,35 @@ Array [
             }
           }
         />
+        <View
+          style={
+            Object {
+              "backgroundColor": "grey",
+              "flex": 1,
+              "flexDirection": "column",
+              "margin": 2,
+            }
+          }
+        />
+        <View
+          style={
+            Object {
+              "backgroundColor": "grey",
+              "flex": 1,
+              "flexDirection": "column",
+              "margin": 2,
+            }
+          }
+        />
+      </View>
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "flexDirection": "row",
+          }
+        }
+      >
         <View
           style={
             Object {
@@ -307,7 +257,7 @@ Array [
                 }
               }
             >
-              t
+              c
             </Text>
           </View>
         </View>
@@ -337,7 +287,7 @@ Array [
                 }
               }
             >
-              e
+              a
             </Text>
           </View>
         </View>
@@ -367,37 +317,7 @@ Array [
                 }
               }
             >
-              s
-            </Text>
-          </View>
-        </View>
-        <View
-          style={
-            Object {
-              "backgroundColor": "grey",
-              "flex": 1,
-              "flexDirection": "column",
-              "margin": 2,
-            }
-          }
-        >
-          <View
-            style={
-              Object {
-                "alignItems": "center",
-                "flex": 1,
-                "justifyContent": "center",
-              }
-            }
-          >
-            <Text
-              style={
-                Object {
-                  "fontSize": 30,
-                }
-              }
-            >
-              t
+              r
             </Text>
           </View>
         </View>
@@ -412,7 +332,10 @@ Array [
       }
     >
       <Text>
-        Example
+        Words: 2
+      </Text>
+      <Text>
+        Words[0]: {"englishWord":"car","frenchWord":"voiture"}
       </Text>
     </View>
   </View>,

--- a/src/components/__tests__/__snapshots__/Grid.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Grid.test.tsx.snap
@@ -1,0 +1,309 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders 1`] = `
+Array [
+  <View
+    style={
+      Object {
+        "flex": 3,
+        "flexDirection": "column",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "backgroundColor": "grey",
+            "flex": 1,
+            "flexDirection": "column",
+            "margin": 2,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "backgroundColor": "grey",
+            "flex": 1,
+            "flexDirection": "column",
+            "margin": 2,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "backgroundColor": "grey",
+            "flex": 1,
+            "flexDirection": "column",
+            "margin": 2,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "backgroundColor": "grey",
+            "flex": 1,
+            "flexDirection": "column",
+            "margin": 2,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "backgroundColor": "grey",
+            "flex": 1,
+            "flexDirection": "column",
+            "margin": 2,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "backgroundColor": "grey",
+            "flex": 1,
+            "flexDirection": "column",
+            "margin": 2,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "backgroundColor": "grey",
+            "flex": 1,
+            "flexDirection": "column",
+            "margin": 2,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "backgroundColor": "grey",
+            "flex": 1,
+            "flexDirection": "column",
+            "margin": 2,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "backgroundColor": "grey",
+            "flex": 1,
+            "flexDirection": "column",
+            "margin": 2,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "backgroundColor": "grey",
+            "flex": 1,
+            "flexDirection": "column",
+            "margin": 2,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "backgroundColor": "grey",
+            "flex": 1,
+            "flexDirection": "column",
+            "margin": 2,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "backgroundColor": "grey",
+            "flex": 1,
+            "flexDirection": "column",
+            "margin": 2,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "backgroundColor": "grey",
+            "flex": 1,
+            "flexDirection": "column",
+            "margin": 2,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "backgroundColor": "grey",
+            "flex": 1,
+            "flexDirection": "column",
+            "margin": 2,
+          }
+        }
+      />
+      <View
+        style={
+          Object {
+            "backgroundColor": "grey",
+            "flex": 1,
+            "flexDirection": "column",
+            "margin": 2,
+          }
+        }
+      />
+    </View>
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "backgroundColor": "grey",
+            "flex": 1,
+            "flexDirection": "column",
+            "margin": 2,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontSize": 30,
+              }
+            }
+          >
+            c
+          </Text>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "grey",
+            "flex": 1,
+            "flexDirection": "column",
+            "margin": 2,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontSize": 30,
+              }
+            }
+          >
+            a
+          </Text>
+        </View>
+      </View>
+      <View
+        style={
+          Object {
+            "backgroundColor": "grey",
+            "flex": 1,
+            "flexDirection": "column",
+            "margin": 2,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            style={
+              Object {
+                "fontSize": 30,
+              }
+            }
+          >
+            r
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>,
+]
+`;

--- a/src/components/__tests__/__snapshots__/Results.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Results.test.tsx.snap
@@ -23,7 +23,7 @@ Array [
     </Text>
     <TextInput
       allowFontScaling={true}
-      placeholder="Search for a word among 1645 words..."
+      placeholder="Search for a word among 2 words..."
       rejectResponderTermination={true}
       style={
         Object {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -1,6 +1,9 @@
 // Vendor
 import flatten from "lodash/flatten";
 
+// Internal
+import { Word } from "../types/interfaces";
+
 export const HEADER_Y = 25;
 export const MAX_LETTER_COUNT = 10;
 export const MIN_LETTER_COUNT = 2;
@@ -22,17 +25,17 @@ const DATA: any = {
   letterCountIs7: require("../data/words/7-letters.json"),
   letterCountIs8: require("../data/words/8-letters.json"),
   letterCountIs9: require("../data/words/9-letters.json"),
-  letterCountIs10: require("../data/words/10-letters.json")
+  letterCountIs10: require("../data/words/10-letters.json"),
 };
 
 const allLetterCounts = Array.from(
   { length: MAX_LETTER_COUNT },
   (_v, k) => k + 1
-).filter(v => v >= MIN_LETTER_COUNT);
+).filter((v) => v >= MIN_LETTER_COUNT);
 
-const jsonArrayTemp = allLetterCounts.map(v => {
+const jsonArrayTemp = allLetterCounts.map((v) => {
   const key = `letterCountIs${v}`;
   return DATA[key];
 });
 
-export const ALL_WORDS = flatten(jsonArrayTemp);
+export const ALL_WORDS = flatten(jsonArrayTemp) as Word[];

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -2,14 +2,17 @@
 import flatten from "lodash/flatten";
 
 // Internal
+import { getFromEnv } from "../helpers/env";
 import { Word } from "../types/interfaces";
 
+export const GAME_ROWS = 6;
 export const HEADER_Y = 25;
 export const MAX_LETTER_COUNT = 10;
 export const MIN_LETTER_COUNT = 2;
 export const MIN_SEARCH_LETTER_COUNT = 2;
 
-export const GAME_ROWS = 6;
+export const NODE_ENV = getFromEnv("NODE_ENV") || "development";
+export const IS_TEST = NODE_ENV === "test";
 
 /*
   TODO: fix if possible

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -3,6 +3,7 @@ import flatten from "lodash/flatten";
 
 // Internal
 import { getFromEnv } from "../helpers/env";
+import { mockWords } from "../mocks";
 import { Word } from "../types/interfaces";
 
 export const GAME_ROWS = 6;
@@ -41,4 +42,6 @@ const jsonArrayTemp = allLetterCounts.map((v) => {
   return DATA[key];
 });
 
-export const ALL_WORDS = flatten(jsonArrayTemp) as Word[];
+export const ALL_WORDS = IS_TEST
+  ? mockWords
+  : (flatten(jsonArrayTemp) as Word[]);

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -15,6 +15,8 @@ export const MIN_SEARCH_LETTER_COUNT = 2;
 export const NODE_ENV = getFromEnv("NODE_ENV") || "development";
 export const IS_TEST = NODE_ENV === "test";
 
+export const SPECTATOR_INTERVAL = 5000;
+
 /*
   TODO: fix if possible
   React-native does not support dynamic imports apparently

--- a/src/helpers/__tests__/env.test.ts
+++ b/src/helpers/__tests__/env.test.ts
@@ -1,0 +1,18 @@
+// Internal
+import { getFromEnv } from "../env";
+
+describe("env helper", () => {
+  describe("getFromEnv", () => {
+    let result: string;
+
+    it("returns environment values", () => {
+      result = getFromEnv("NODE_ENV");
+      expect(result).toBe("test");
+    });
+
+    it("returns empty string otherwise", () => {
+      result = getFromEnv("UNKNOWN");
+      expect(result).toBe("");
+    });
+  });
+});

--- a/src/helpers/__tests__/score.test.ts
+++ b/src/helpers/__tests__/score.test.ts
@@ -1,14 +1,15 @@
 // Internal
-import { getLetterScore } from "../score";
+import { getLetterScore, getWordScore } from "../score";
 
 describe("score helpers", () => {
+  let result: number;
+
   it("exports the following helpers", () => {
     expect(typeof getLetterScore).toBe("function");
+    expect(typeof getWordScore).toBe("function");
   });
 
   describe("getLetterScore", () => {
-    let result: number;
-
     it("returns 0 when not a letter", () => {
       expect(getLetterScore("")).toBe(0);
       expect(getLetterScore("word")).toBe(0);
@@ -72,6 +73,21 @@ describe("score helpers", () => {
       expect(getLetterScore("X")).toBe(8);
       expect(getLetterScore("Y")).toBe(4);
       expect(getLetterScore("Z")).toBe(10);
+    });
+  });
+
+  describe("getWordScore", () => {
+    it("returns 0 when empty strings", () => {
+      result = getWordScore({ englishWord: "", frenchWord: "" });
+      expect(result).toBe(0);
+    });
+
+    it("returns correct score for a word", () => {
+      result = getWordScore({ englishWord: "bike", frenchWord: "" });
+      expect(result).toBe(10);
+
+      result = getWordScore({ englishWord: "bike", frenchWord: "vélo" });
+      expect(result).toBe(10);
     });
   });
 });

--- a/src/helpers/env.ts
+++ b/src/helpers/env.ts
@@ -1,0 +1,3 @@
+const getFromEnv = (key: string) => process.env[key] || "";
+
+export { getFromEnv };

--- a/src/helpers/score.ts
+++ b/src/helpers/score.ts
@@ -19,15 +19,11 @@ const getLetterScore = (character: string) => {
 };
 
 const getWordScore = (word: Word) => {
-  const letters = word.englishWord;
-  const lettersScore = letters
-    .split("")
-    .map((letter) => getLetterScore(letter));
+  const { englishWord } = word;
+  const letters = englishWord.split("");
+  const lettersScore = letters.map((letter) => getLetterScore(letter));
 
-  const reducer = (accumulator: number, currentValue: number) => {
-    return accumulator + currentValue;
-  };
-
+  const reducer = (acc: number, val: number) => acc + val;
   const score = lettersScore.reduce(reducer, 0);
 
   return score;

--- a/src/helpers/score.ts
+++ b/src/helpers/score.ts
@@ -1,3 +1,6 @@
+// Internal
+import { Word } from "../types/interfaces";
+
 const getLetterScore = (character: string) => {
   if (character.length !== 1) return 0;
 
@@ -15,4 +18,19 @@ const getLetterScore = (character: string) => {
   return 0;
 };
 
-export { getLetterScore };
+const getWordScore = (word: Word) => {
+  const letters = word.englishWord;
+  const lettersScore = letters
+    .split("")
+    .map((letter) => getLetterScore(letter));
+
+  const reducer = (accumulator: number, currentValue: number) => {
+    return accumulator + currentValue;
+  };
+
+  const score = lettersScore.reduce(reducer, 0);
+
+  return score;
+};
+
+export { getLetterScore, getWordScore };

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,0 +1,9 @@
+// Internal
+import { Word } from "../types/interfaces";
+
+const mockWords: Word[] = [
+  { englishWord: "car", frenchWord: "voiture" },
+  { englishWord: "cat", frenchWord: "chat" },
+];
+
+export { mockWords };

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -1,0 +1,4 @@
+export interface Word {
+  englishWord: string;
+  frenchWord: string;
+}


### PR DESCRIPTION
# Overview

**Previously,** there was no dynamic logic between the words.
**Now,** a series of words' transitions is being played on the screen with barebone design.

# Testing

- [x] App should be available on a real device (iPhone) after running `npm run start`

# Additional information

- Removing "`npm run test` should be ✅" from the template thanks to CI
- a helper was created for calculating a word's score
- the display logic moved from `Game` to `Grid`
- test environment helper got brought back as well